### PR TITLE
Add some fuels and oxidizers to the weapons factories

### DIFF
--- a/resources/custom/lang/en_us.lang
+++ b/resources/custom/lang/en_us.lang
@@ -56,6 +56,10 @@ fluid.hot_compressed_propane=Hot Compressed Propane
 fluid.compressed_propane=Compressed Propane
 fluid.cold_propane=Cold Propane
 
+# Simple Materials
+metaitem.zircon.mold.base.name=Zircon Mold Base
+metaitem.ammonium_nitrate.name=Solid Ammonium Nitrate
+
 # GregTech RecipeMaps
 
 recipemap.fluid_de_compressor.name=Fluid (De)Compression

--- a/scripts/chemistry/general_chemistry.zs
+++ b/scripts/chemistry/general_chemistry.zs
@@ -1,0 +1,14 @@
+import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.oredict.IOreDictEntry;
+
+import mods.gregtech.recipe.RecipeMap;
+
+fluid_solidifier.recipeBuilder()
+    .notConsumable(<metaitem:shape.mold.ball>)
+    .fluidInputs(<liquid:ammonium_nitrate> * 250)
+    .outputs(<metaitem:ammonium_nitrate>)
+    .duration(40)
+    .EUt(16)
+    .buildAndRegister();

--- a/scripts/custom_materials.zs
+++ b/scripts/custom_materials.zs
@@ -9,6 +9,7 @@ import mods.gregtech.material.MaterialRegistry;
 //-----------------------------------DUSTS-----------------------------------
 
 Utils.registerDust("zircon.mold.base", 1200, 15441471, "DULL");
+Utils.registerDust("ammonium_nitrate", 1201, 0xDEDEDE, "ROUGH");
 
 //-----------------------------------FLUIDS-----------------------------------
 

--- a/scripts/multiblocktweaker/large_weapons_factory.zs
+++ b/scripts/multiblocktweaker/large_weapons_factory.zs
@@ -133,23 +133,32 @@ recipes.addShaped(
 );
 
 val solidfuels as IOreDictEntry[] = [
-	<ore:dustSugar>
+	<ore:dustSugar>,
+	<ore:dustGunpowder>,
+	<ore:dustAluminium>,
+	<ore:dustBeryllium>,
+	<ore:dustHexanitrohexaaxaisowurtzitane>
 ];
 
 val solidoxys as IOreDictEntry[] = [
-	<ore:dustSaltpeter>
+	<ore:dustSaltpeter>,
+	<ore:dustNiter>, // this will be merged into saltpeter in CEu
+	<ore:dustAmmoniumNitrate>
 ];
 
 val liquidfuels as ILiquidStack[] = [
 	<liquid:liquid_hydrogen>,
+	<liquid:ethane>,
 	<liquid:ethanol>,
-	<liquid:rp>
+	<liquid:rp>,
+	<liquid:monomethylhydrazine>
 ];
 
 val liquidoxys as ILiquidStack[] = [
 	<liquid:liquid_oxygen>,
 	<liquid:hydrogen_peroxide>,
-	<liquid:nitric_acid>
+	<liquid:nitric_acid>,
+	<liquid:dinitrogen_tetroxide>
 ];
 
 for solder in soldering_alloys {


### PR DESCRIPTION
This PR adds some more fuels and oxidizers to the weapons factories. There is a massive amount of them present in GTCE + Gregicality, but I decided to go with the ones that make more sense and fit better for gameplay.

This PR also adds Solid Ammonium Nitrate made in a fluid solidifier, which could be useful for future recipes. It is solidified to the proper amount of dust moles, such that 1000mB is 2 dust.