### PR TITLE
Disable nether mob spawns

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -64,6 +64,10 @@
     "result": "deny"
   },
   {
+	"dimension": -1,
+    "result": "deny"
+  },
+  {
 	"dimension": 10,
 	"mob": [
 		"minecraft:spider",


### PR DESCRIPTION
Removes pigmen, ghasts, other vanilla magic mobs, etc.

Not sure about fortress blazes though, but nether fortresses as a whole are getting removed in a different way