### PR TITLE
add [build skip] so that github doesnt run nightly 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, '[build skip]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,10 +8,11 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[build skip]')"
+    name: "Pre Release"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
@@ -34,13 +35,12 @@ jobs:
       env:
         CFAPIKEY: ${{ secrets.CFAPIKEY }}
     - name: Automatic Releases
-      uses: marvinpinto/action-automatic-releases@v1.1.1
+      uses: marvinpinto/action-automatic-releases@latest
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: true
           title: ${{ steps.vars.outputs.sha_short }}
-
           files: |
             buildOut/client.zip
             buildOut/server.zip


### PR DESCRIPTION
...on useless commits like this
## What
Title. Stops github workflow from building if `[build skip]` is included on the title. obviously commits like this or updating readme doesnt need to be built
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->

## Implementation Details
If you add `[build skip]` on the pr title, the workflow will ignore it
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->

## Outcome
less build spam
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->
