### PR TITLE
Add GTFO crops to Serene Seasons

### DIFF
--- a/config/gregtechfoodoption.cfg
+++ b/config/gregtechfoodoption.cfg
@@ -2,7 +2,7 @@
 
 general {
     # Turn on GTFO tree generation? Required for many mod features.
-    B:enableGTFOTrees=false
+    B:enableGTFOTrees=true
 
     # Show tooltips always, regardless of what keys are held?
     B:showTooltipsAlways=true

--- a/config/sereneseasons/cropfertility.cfg
+++ b/config/sereneseasons/cropfertility.cfg
@@ -10,7 +10,7 @@ general_category {
     # Maximum height greenhouse glass can be above a crop for it to be fertile out of season
     I:greenhouse_glass_max_height=7
 
-    # Whether unlisted seeds are fertile every season. False means they're fertile every season except Winter
+    # Whether unlisted seeds are fertile every season. False means they're fertile every season except Winter (KEEP ON FOR GTFO CROPS)
     B:ignore_unlisted_crops=false
 
     # Whether crops are affected by seasons.
@@ -97,6 +97,7 @@ seasonal_fertility {
         growthcraft_milk:thistle
         growthcraft_rice:rice
         growthcraft_rice:riceCrop
+        gregtechfoodoption:crop_pea
      >
 
     # Crops growable in Spring (List either the seed item for the crop, or the crop block itself)
@@ -173,6 +174,15 @@ seasonal_fertility {
         harvestcraft:quinoaseeditem
         growthcraft_rice:rice
         growthcraft_rice:riceCrop
+        gregtechfoodoption:crop_tomato
+        gregtechfoodoption:crop_onion
+        gregtechfoodoption:crop_cucumber
+        gregtechfoodoption:crop_grape
+        gregtechfoodoption:crop_white_grape
+        gregtechfoodoption:crop_pea
+        gregtechfoodoption:crop_oregano
+        gregtechfoodoption:crop_horseradish
+        gregtechfoodoption:crop_artichoke
      >
 
     # Crops growable in Summer (List either the seed item for the crop, or the crop block itself)
@@ -292,6 +302,15 @@ seasonal_fertility {
         growthcraft_milk:thistle
         growthcraft_rice:rice
         growthcraft_rice:riceCrop
+        gregtechfoodoption:crop_coffee
+        gregtechfoodoption:crop_tomato
+        gregtechfoodoption:crop_onion
+        gregtechfoodoption:crop_cucumber
+        gregtechfoodoption:crop_grape
+        gregtechfoodoption:crop_white_grape
+        gregtechfoodoption:crop_oregano
+        gregtechfoodoption:crop_horseradish
+        gregtechfoodoption:crop_artichoke
      >
 
     # Crops growable in Winter (List either the seed item for the crop, or the crop block itself)
@@ -300,6 +319,8 @@ seasonal_fertility {
         minecraft:nether_wart
         minecraft:red_mushroom
         minecraft:brown_mushroom
+        gregtechfoodoption:crop_tomato
+        gregtechfoodoption:crop_horseradish
      >
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     {
       "projectID": 477021,
-      "fileID": 4480325,
+      "fileID": 4493938,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     {
       "projectID": 477021,
-      "fileID": 4493938,
+      "fileID": 4494894,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     {
       "projectID": 477021,
-      "fileID": 4494894,
+      "fileID": 4496053,
       "required": true
     },
     {


### PR DESCRIPTION
## What
Adds specific growth seasons to GTFO crops, which did not exist before.

## Implementation Details
Perhaps the functionality of this could be verified in-game, but it was fine for me. Furthermore, tooltips for which seasons they grow in are not currently added.

## Outcome
Adds specific growth seasons to GTFO crops.