### PR TITLE
Remove libvulpes recipes

### DIFF
--- a/groovy/postInit/mod/LibVulpes.groovy
+++ b/groovy/postInit/mod/LibVulpes.groovy
@@ -1,0 +1,22 @@
+def name_removals = [
+    "libvulpes:inputhatch",
+    "libvulpes:outputhatch",
+    "libvulpes:fluidinputhatch",
+    "libvulpes:fluidoutputhatch",
+    "libvulpes:structuremachine",
+    "libvulpes:advstructuremachine",
+    "libvulpes:forgepowerinput",
+    "libvulpes:coalgenerator",
+    "libvulpes:basicmotor",
+    "libvulpes:advancedmotor",
+    "libvulpes:enhancedmotor",
+    "libvulpes:elitemotor",
+    "libvulpes:blockgtplug",
+    "libvulpes:linker",
+    "libvulpes:battery",
+    "libvulpes:advbattery"
+]
+
+for (name in name_removals) {
+    crafting.remove(name)
+}


### PR DESCRIPTION
## What
Removes libvulpes recipes that are not intended to be in the pack.

## Implementation Details
Single groovy file removing the recipes.

## Outcome
Undesired recipes are now removed.
