### PR TITLE
Fixed "invisible" clay in coke clay recipe

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -140,7 +140,7 @@ mods.gregtech.electric_blast_furnace.recipeBuilder()
         .buildAndRegister();
 
 crafting.addShaped('gregtech:compressed_coke_clay', metaitem('compressed.coke_clay') * 8, [
-    [ore('itemClay'), ore('itemClay'), ore('itemClay')],
+    [ore('ingotClay'), ore('ingotClay'), ore('ingotClay')],
     [ore('sand'), metaitem('wooden_form.brick'), ore('sand')],
     [ore('sand'), ore('sand'), ore('sand')]
 ])


### PR DESCRIPTION
## What
Clay does not currently show in jei when you look at the recipe for compressed coke clay.

## Implementation Details
Changed the oredict string in the recipe from 'itemClay' to 'ingotClay'. Likely an accident when regian committed the "make coke oven easier..." change. 

## Outcome
Correctly shows clay being required in the top three slots of the recipe

## Additional Information
![image](https://user-images.githubusercontent.com/122228099/233239041-91831b1e-ef80-4e46-be3f-b1cedd9ec4c2.png)
![image](https://user-images.githubusercontent.com/122228099/233239066-48f77fd6-66d5-45f3-afbf-bd967b4197d9.png)

## Potential Compatibility Issues
It is possible that this oredict name wasn't an accident and that I am unaware of it being different for some reason, but I believe that is unlikely. 