### PR TITLE
Fixes lead drum recipe, adds nbt removal recipe

### DIFF
--- a/groovy/postInit/progression/Batteries.groovy
+++ b/groovy/postInit/progression/Batteries.groovy
@@ -38,6 +38,14 @@ crafting.addShapeless("drum_nbt_lead", metaitem('drum.lead'), [
         metaitem('drum.lead').noreturn()
 ]);
 
+mods.gregtech.assembler.recipeBuilder()
+        .inputs(ore('stickLongLead') * 2)
+        .inputs(ore('plateLead') * 4)
+        .outputs(metaitem('drum.lead'))
+        .duration(200)
+        .EUt(16)
+        .buildAndRegister()
+
 MIXER_RECIPES.recipeBuilder()
 .fluidInputs(Materials.SulfurTrioxide.getFluid(1000))
 .fluidInputs(Materials.Water.getFluid(1000))

--- a/groovy/postInit/progression/Batteries.groovy
+++ b/groovy/postInit/progression/Batteries.groovy
@@ -27,11 +27,17 @@ crafting.addShaped("anode_lead", metaitem('anode.lead'), [
         [null,metaitem('plateLead'),metaitem('cableGtSingleTin')],
         [null,null,null]
 ]);
+
 crafting.addShaped("drum_lead", metaitem('drum.lead'), [
-        [null,null,null],
+        [null,ore('craftingToolHardHammer'),null],
         [metaitem('plateLead'),metaitem('stickLongLead'),metaitem('plateLead')],
         [metaitem('plateLead'),metaitem('stickLongLead'),metaitem('plateLead')]
 ]);
+
+crafting.addShapeless("drum_nbt_lead", metaitem('drum.lead'), [
+        metaitem('drum.lead').noreturn()
+]);
+
 MIXER_RECIPES.recipeBuilder()
 .fluidInputs(Materials.SulfurTrioxide.getFluid(1000))
 .fluidInputs(Materials.Water.getFluid(1000))

--- a/groovy/postInit/progression/Batteries.groovy
+++ b/groovy/postInit/progression/Batteries.groovy
@@ -44,6 +44,7 @@ mods.gregtech.assembler.recipeBuilder()
         .outputs(metaitem('drum.lead'))
         .duration(200)
         .EUt(16)
+        .notConsumable(Globals.circuit(2))
         .buildAndRegister()
 
 MIXER_RECIPES.recipeBuilder()


### PR DESCRIPTION
## What
Brings lead drum recipes in line with other drums

## Implementation Details
Adds hard hammer requirement to crafting recipe, creates shapeless recipe which allows for nbt removal.

## Outcome
Brings lead drum more in line with other drums and provides functionality in the form of the nbt removal recipe.

## Additional Information
![image](https://user-images.githubusercontent.com/122228099/233326895-4b3cc54d-2b36-4eab-be61-1f2254d3db7b.png)
![image](https://user-images.githubusercontent.com/122228099/233332186-519e26c7-1bd6-4534-b435-b1f2182e6a41.png)
![image](https://user-images.githubusercontent.com/122228099/233332919-a90ec35e-0df2-41a4-8dec-2cab3677d65d.png)

## Potential Compatibility Issues
Name of crafting recipe does not follow the same pattern as the other metal drums; name reflects meta id. (This was the case before this commit as well)
