### PR TITLE
Minor Chapter 0 Questbook Revisions (Mostly for Clarity)

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -549,7 +549,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your new Flint Knife can be used for cutting things, making things into shards, or getting §aplant fibers§r§..\n\nTo cut items other than blocks, you need to have the item you want to cut in your §0§aoffhand,§r and the knife in your §amain hand.§r This works vice versa.\n\nYou can also use the flint knife as a weapon.",
+          "desc:8": "Your new §eFlint Knife § can be used for cutting things,§f making things into shards, or getting §aplant fibers§r§..\n\nTo cut items other than blocks, you need to have the item you want to cut in your §0§aoffhand,§r and the knife in your §amain hand.§r This works vice versa.\n\nYou can also use the flint knife as a weapon.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -619,7 +619,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can use your shiny new §eflint knife§r to make plant fibers. \n\nYou can get §aplant fibers§r by breaking §2tall grass §rwith your flint knife.\nYou can pack those §aplant fibers§r into §aplant string§r.",
+          "desc:8": "You can use your shiny new §eflint knife§r to make plant fibers. \n\nYou can get §aplant fibers§r by breaking §2tall grass §rwith your flint knife.\nYou can then pack those §aplant fibers§r into §aplant string§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1382,7 +1382,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Bronze§r is an alloy consisting of 75% copper combined with about 25% tin.\n\nMix the dusts in a §acrafting table§r in a 3 to 1 ratio to make §6bronze dust§r. Then you must smelt it in a furnace to get bronze ingots.\n\n§3This will unlock Tier 1.",
+          "desc:8": "§6Bronze§r is an alloy consisting of 75% copper combined with about 25% tin.\n\nMix the dusts in a §acrafting table§r in a 3 to 1 ratio to make §6bronze dust§r. Then you must smelt it in a furnace to get bronze ingots.\n\nCrafting the dusts by hand will only yield 3 §6bronze dust§r per batch. However, you can craft 4 with the same amount later on using a §6Mixer§f.\n\n§3This will unlock Tier 1.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1456,7 +1456,7 @@
               "id:8": "libvulpes:productdust"
             },
             "2:10": {
-              "Count:3": 4,
+              "Count:3": 3,
               "Damage:2": 260,
               "ForgeCaps:10": {
                 "regeneration:arch:10": {
@@ -1471,7 +1471,7 @@
               "id:8": "gregtech:meta_dust"
             },
             "3:10": {
-              "Count:3": 4,
+              "Count:3": 3,
               "Damage:2": 260,
               "ForgeCaps:10": {
                 "regeneration:arch:10": {
@@ -1594,7 +1594,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Breaking leaves§r with a piece of Flint§r or a Flint Knife will drop a stick. ",
+          "desc:8": "Breaking leaves§r with a piece of Flint§r or a Flint Knife will drop a stick. However, Flint Shards will not work.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1700,7 +1700,7 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
-              "Count:3": 25,
+              "Count:3": 29,
               "Damage:2": 8,
               "OreDict:8": "",
               "id:8": "gregtech:metal_casing"
@@ -1998,16 +1998,16 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
-              "Count:3": 1,
-              "Damage:2": 1000,
-              "OreDict:8": "",
-              "id:8": "gregtech:machine"
-            },
-            "1:10": {
               "Count:3": 33,
               "Damage:2": 1,
               "OreDict:8": "",
               "id:8": "gregtech:metal_casing"
+            },
+            "1:10": {
+              "Count:3": 1,
+              "Damage:2": 1000,
+              "OreDict:8": "",
+              "id:8": "gregtech:machine"
             }
           },
           "taskID:8": "bq_standard:retrieval"
@@ -2420,7 +2420,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "We can make better tools out of §6bronze§r. You need to make the tool parts first, and then assemble the tool.\n\nThe bronze axe can cut down entire trees with just one click.\n\nThe bronze mining hammer can mine an entire 3x3 meter area with one click, unless you\u0027re pressing §aSHIFT§r.\n\n§c§lBoth JEI and the book will show iron tools wherever tools are used. Tools other than iron will not show up in the JEI search. Bronze tools exist and should be made first. Generally, recipes accept all kinds of tools.§r",
+          "desc:8": "We can make better tools out of §6bronze§r. You need to make the tool parts first, and then assemble the tool.\n\nThe bronze axe can cut down entire trees with just one click.\n\nThe bronze mining hammer can mine an entire 3x3 meter area with one click, unless you\u0027re pressing §aSHIFT§r.\n\nThe bronze spade does the same thing as the mining hammer, except it works with blocks which work with shovels, such as dirt and sand.\n\n§c§lBoth JEI and the book will show iron tools wherever tools are used. Tools other than iron will not show up in the JEI search. Bronze tools exist and should be made first. Generally, recipes accept all kinds of tools.§r",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -2435,7 +2435,29 @@
               }
             },
             "OreDict:8": "",
-            "id:8": "minecraft:iron_axe"
+            "id:8": "gregtech:mining_hammer",
+            "tag:10": {
+              "DisallowContainerItem:1": 0,
+              "GT.Behaviours:10": {
+                "AoEColumn:3": 1,
+                "AoELayer:3": 0,
+                "AoERow:3": 1,
+                "MaxAoEColumn:3": 1,
+                "MaxAoELayer:3": 0,
+                "MaxAoERow:3": 1,
+                "TorchPlacing:1": 1
+              },
+              "GT.Tool:10": {
+                "AttackDamage:5": 3.5,
+                "AttackSpeed:5": -3.2,
+                "Durability:3": 0,
+                "HarvestLevel:3": 2,
+                "Material:8": "iron",
+                "MaxDurability:3": 768,
+                "ToolSpeed:5": 4.8
+              },
+              "HideFlags:3": 2
+            }
           },
           "ignoresview:1": 0,
           "ismain:1": 0,
@@ -2519,6 +2541,42 @@
                   "MaxAoELayer:3": 0,
                   "MaxAoERow:3": 1,
                   "TorchPlacing:1": 1
+                },
+                "GT.Tool:10": {
+                  "AttackDamage:5": 3.5,
+                  "AttackSpeed:5": -3.2,
+                  "Durability:3": 0,
+                  "HarvestLevel:3": 2,
+                  "Material:8": "iron",
+                  "MaxDurability:3": 768,
+                  "ToolSpeed:5": 4.8
+                },
+                "HideFlags:3": 2
+              }
+            },
+            "2:10": {
+              "Count:3": 1,
+              "Damage:2": 0,
+              "ForgeCaps:10": {
+                "regeneration:arch:10": {
+                  "arch_status:8": "NORMAL_ITEM",
+                  "regenAmount:3": 0,
+                  "skin:8": "NONE",
+                  "skinType:8": "STEVE",
+                  "trait:8": "regeneration:boring"
+                }
+              },
+              "OreDict:8": "",
+              "id:8": "gregtech:spade",
+              "tag:10": {
+                "DisallowContainerItem:1": 0,
+                "GT.Behaviours:10": {
+                  "AoEColumn:3": 1,
+                  "AoELayer:3": 0,
+                  "AoERow:3": 1,
+                  "MaxAoEColumn:3": 1,
+                  "MaxAoELayer:3": 0,
+                  "MaxAoERow:3": 1
                 },
                 "GT.Tool:10": {
                   "AttackDamage:5": 3.5,
@@ -4638,7 +4696,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "In the Industrial Age you are able to produce better weapons. The §aHandcannon §ris one of those. It uses stone bullets for ammunition. ",
+          "desc:8": "In the Industrial Age you are able to produce better weapons. The §aHandcannon §ris one of those. It uses stone bullets as ammunition. ",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4733,7 +4791,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aDouble Barrel Shotgun§r is the first ever gun that you can make. It uses §aShotgun Rounds §o§rfor ammo.\n\nIt\u0027s a shotgun, this means it will shoot 8 times at once. For more info, look at the tooltip.",
+          "desc:8": "The §aDouble Barrel Shotgun§r is the first ever gun that you can make. It uses §aShotgun Rounds §o§rfor ammo.\n\nIt\u0027s a shotgun, this means it will fire 8 projectiles at once. For more info, look at the tooltip.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6603,7 +6661,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Convert 1 log into 4 §6planks§r. \n\nYou can then craft those planks into a §aworkbench§r.",
+          "desc:8": "Convert 1 log into 4 §6planks§r. \n\nYou can then craft those planks into a §acrafting table§f.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6795,7 +6853,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coal can be turned into §bcoal coke§r, a fuel §rand §btorches§,, sources of light. §rCoal deposits are found in every biome.\n\n",
+          "desc:8": "§7Coal §fcan be turned into §b§7Coal Coke§f, a fuel, §rand §btorches§,, sources of light. §rCoal deposits are found in every biome.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9015,16 +9073,16 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
+              "Count:3": 16,
+              "Damage:2": 0,
+              "OreDict:8": "",
+              "id:8": "gregtechfoodoption:gtfo_casing"
+            },
+            "1:10": {
               "Count:3": 1,
               "Damage:2": 8516,
               "OreDict:8": "",
               "id:8": "gregtech:machine"
-            },
-            "1:10": {
-              "Count:3": 1,
-              "Damage:2": 0,
-              "OreDict:8": "",
-              "id:8": "gregtechfoodoption:gtfo_casing"
             },
             "2:10": {
               "Count:3": 1,
@@ -12279,14 +12337,14 @@
           "id:3": 13,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 30,
+          "x:3": 28,
           "y:3": 420
         },
         "13:10": {
           "id:3": 14,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": -48,
+          "x:3": -52,
           "y:3": 420
         },
         "14:10": {
@@ -12294,7 +12352,7 @@
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -12,
-          "y:3": 450
+          "y:3": 448
         },
         "15:10": {
           "id:3": 16,
@@ -14124,7 +14182,7 @@
   },
   "questSettings:10": {
     "betterquesting:10": {
-      "editmode:1": 0,
+      "editmode:1": 1,
       "hardcore:1": 0,
       "home_anchor_x:5": 0.5,
       "home_anchor_y:5": 0.0,


### PR DESCRIPTION
## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->

- Changed color of some names mentioned to be more consistent
- Added an iron spade to the Gregic Tools quest
- Changed Gregic Tools quest icon to be a mining hammer
- Changed the Alloying 101 quest to only require 3 bronze dust and 3 bronze ingots
- Disclaimer about attempting to use flint shards to acquire sticks from leaves
- Reordered blast furnace & baking oven requirements
- Changed number of required bricks for baking oven and coke oven
- Fixed minor symmetry issue with Copper and Tin quests
- Some grammar changes
## Why
- Consistency is important
- When I discovered the Gregtech spade for the first time, I wondered why nobody has told me about it previously. Also it's pretty neat for terraforming
- The hand crafting recipe for bronze dust only produces 3 bronze dust from 3 copper dust and 1 tin dust. The quest was false advertising for the technology you have smh. Also added in something that tells you that you can get all 4 bronze dust if you have a Mixer. 
- When I first acquired flint shards during playtesting I wondered if the flint shards could be used. They couldn't. Added this in for clarity.
- The bricks themselves are ingredients for the multiblock controllers. Reordering them in the quest should convince people to make them first as a result.
- Related to the above issue, where if you fulfilled the brick requirements for the multiblocks first you would still need more bricks afterwards. 
- There is a minor alignment issue, they are not symmetrical relative to the mortar quest.
- Nerd emoji or something