### PR TITLE
Gave rubber trees NTP features

### DIFF
--- a/config/dropt/leaves.json
+++ b/config/dropt/leaves.json
@@ -15,7 +15,10 @@
 			"gregtech:leaves:*",
 			"quark:variant_leaves:*",
 			"gregtech:leaves:0",
-			"gregtech:rubber_leaves:*"
+			"gregtech:rubber_leaves:*",
+			"gregtechfoodoption:gtfo_leaves_0:*",
+      		"gregtechfoodoption:gtfo_leaves_1:*",
+      		"gregtechfoodoption:gtfo_leaves_2:*"
           ]
         },
         "harvester": {

--- a/config/dropt/leaves.json
+++ b/config/dropt/leaves.json
@@ -14,7 +14,8 @@
 			"biomesoplenty:leaves_5:*",
 			"gregtech:leaves:*",
 			"quark:variant_leaves:*",
-			"gregtech:leaves:0"
+			"gregtech:leaves:0",
+			"gregtech:rubber_leaves:*"
           ]
         },
         "harvester": {
@@ -50,7 +51,8 @@
 			"biomesoplenty:leaves_5:*",
 			"gregtech:leaves:*",
 			"quark:variant_leaves:*",
-			"gregtech:leaves:0"
+			"gregtech:leaves:0",
+			"gregtech:rubber_leaves:*"
           ]
         },
         "harvester": {

--- a/config/dropt/leaves.json
+++ b/config/dropt/leaves.json
@@ -55,7 +55,10 @@
 			"gregtech:leaves:*",
 			"quark:variant_leaves:*",
 			"gregtech:leaves:0",
-			"gregtech:rubber_leaves:*"
+			"gregtech:rubber_leaves:*",
+			"gregtechfoodoption:gtfo_leaves_0:*",
+      		"gregtechfoodoption:gtfo_leaves_1:*",
+      		"gregtechfoodoption:gtfo_leaves_2:*"
           ]
         },
         "harvester": {

--- a/config/dropt/wood.json
+++ b/config/dropt/wood.json
@@ -11,7 +11,10 @@
 			"biomesoplenty:log_3:*",
 			"biomesoplenty:log_4:*",
 			"gregtech:log:0",
-      "gregtech:rubber_log:*"
+      "gregtech:rubber_log:*",
+      "gregtechfoodoption:gtfo_log_0:*",
+      "gregtechfoodoption:gtfo_log_1:*",
+      "gregtechfoodoption:gtfo_log_2:*"
           ]
         },
         "harvester": {

--- a/config/dropt/wood.json
+++ b/config/dropt/wood.json
@@ -10,7 +10,8 @@
 			"biomesoplenty:log_2:*",
 			"biomesoplenty:log_3:*",
 			"biomesoplenty:log_4:*",
-			"gregtech:log:0"
+			"gregtech:log:0",
+      "gregtech:rubber_log:*"
           ]
         },
         "harvester": {


### PR DESCRIPTION
## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->
GT rubber trees previously were not configured to work with NTP. These changes fix this.

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->

- Rubber tree logs now require a hatchet or axe (you can't punch them anymore)
- Rubber tree leaves now drop sticks when mined with flint
## Implementation Details
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->

- Rubber tree leaves still drop sticks at a rate much less than vanilla & biomes o' plenty leaves for reasons beyond my comprehension
- Rubber tree logs are still broken at the same rate