### PR TITLE
Removed redundant NTP saw recipes

### DIFF
--- a/groovy/postInit/mod/NoTreePunching.groovy
+++ b/groovy/postInit/mod/NoTreePunching.groovy
@@ -1,0 +1,3 @@
+for(int i = 1; i < 35; i++){
+    crafting.remove("notreepunching:saw_planks_" + i.toString());
+}


### PR DESCRIPTION
## What

Removed NTP saw recipes that were unusable anyways due to conflicting with the GT log to plank using saw recipes. Done to remove JEI clutter and avoid confusion.

