### PR TITLE
Engineer's decor stair balance consistencification

### DIFF
--- a/groovy/postInit/mod/EngineersDecor.groovy
+++ b/groovy/postInit/mod/EngineersDecor.groovy
@@ -48,3 +48,39 @@ crafting.replaceShaped('engineersdecor:alternative/thin_steel_pole_recipe_standa
     [null, ore('stickSteel'), null],
     [null, ore('stickSteel'), null]
 ])
+
+crafting.replaceShaped('engineersdecor:independent/clinker_brick_stairs_recipe', item('engineersdecor:clinker_brick_stairs') * 8, [
+    [item('engineersdecor:clinker_brick_block'), null, null],
+    [item('engineersdecor:clinker_brick_block'), item('engineersdecor:clinker_brick_block'), null],
+    [item('engineersdecor:clinker_brick_block'), item('engineersdecor:clinker_brick_block'), item('engineersdecor:clinker_brick_block')]
+])
+
+crafting.replaceShaped('engineersdecor:independent/clinker_brick_stained_stairs_recipe', item('engineersdecor:clinker_brick_stained_stairs') * 8, [
+    [item('engineersdecor:clinker_brick_stained_block'), null, null],
+    [item('engineersdecor:clinker_brick_stained_block'), item('engineersdecor:clinker_brick_stained_block'), null],
+    [item('engineersdecor:clinker_brick_stained_block'), item('engineersdecor:clinker_brick_stained_block'), item('engineersdecor:clinker_brick_stained_block')]
+])
+
+crafting.replaceShaped('engineersdecor:independent/slag_brick_stairs_recipe', item('engineersdecor:slag_brick_stairs') * 8, [
+    [item('engineersdecor:slag_brick_block'), null, null],
+    [item('engineersdecor:slag_brick_block'), item('engineersdecor:slag_brick_block'), null],
+    [item('engineersdecor:slag_brick_block'), item('engineersdecor:slag_brick_block'), item('engineersdecor:slag_brick_block')]
+])
+
+crafting.replaceShaped('engineersdecor:independent/rebar_concrete_stairs_recipe', item('engineersdecor:rebar_concrete_stairs') * 8, [
+    [item('engineersdecor:rebar_concrete'), null, null],
+    [item('engineersdecor:rebar_concrete'), item('engineersdecor:rebar_concrete'), null],
+    [item('engineersdecor:rebar_concrete'), item('engineersdecor:rebar_concrete'), item('engineersdecor:rebar_concrete')]
+])
+
+crafting.replaceShaped('engineersdecor:independent/rebar_concrete_tile_stairs_recipe', item('engineersdecor:rebar_concrete_tile_stairs') * 8, [
+    [item('engineersdecor:rebar_concrete_tile'), null, null],
+    [item('engineersdecor:rebar_concrete_tile'), item('engineersdecor:rebar_concrete_tile'), null],
+    [item('engineersdecor:rebar_concrete_tile'), item('engineersdecor:rebar_concrete_tile'), item('engineersdecor:rebar_concrete_tile')]
+])
+
+crafting.replaceShaped('engineersdecor:independent/gas_concrete_stairs_recipe', item('engineersdecor:gas_concrete_stairs') * 8, [
+    [item('engineersdecor:gas_concrete'), null, null],
+    [item('engineersdecor:gas_concrete'), item('engineersdecor:gas_concrete'), null],
+    [item('engineersdecor:gas_concrete'), item('engineersdecor:gas_concrete'), item('engineersdecor:gas_concrete')]
+])


### PR DESCRIPTION
- Engineer's decor stair recipes now produce 8 stairs instead of 6, like the other stair recipes

I wanted to do the same thing with Techguns but unfortunately the recipes for those involve different recipes for the same block items differentiated only by blockstate, which I don't think Groovyscript can deal with