### PR TITLE
Make Roasting Borax Mv

### DIFF
--- a/groovy/postInit/chains/Chemistry/BoronChain.groovy
+++ b/groovy/postInit/chains/Chemistry/BoronChain.groovy
@@ -16,7 +16,7 @@ ROASTER.recipeBuilder()
 	.outputs(ore('dustSodiumTetraborate').first() * 13)
 	.fluidOutputs(fluid('steam') * 10000)
 	.duration(200)
-	.EUt(Globals.voltAmps[1])
+	.EUt(60)
 	.buildAndRegister()	
 
 //DISSOLUTION OF TETRABORATE


### PR DESCRIPTION
## What
Fixes issue with Lv Roaster Tank Storage being too small for recipe listed as Lv by having recipe now correctly require Mv. 

## Implementation Details
Double Eu/t for roaster recipe which causes problem. 

## Outcome
No longer shown as a valid recipe for Lv and consumes appropriate Eu/t (Mv).
