### PR TITLE
Fix Lv Lathe Recipe Requiring Diamond

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -118,6 +118,12 @@ crafting.replaceShaped("gregtech:steam_rock_breaker_bronze", metaitem('steam_roc
     [ore('gemDiamond'), ore('pipeSmallFluidBronze'), ore('gemDiamond')]
 ])
 
+crafting.replaceShaped("gregtech:gregtech.machine.lathe.lv", metaitem('gregtech:lathe.lv'), [
+    [metaitem('cableGtSingleTin'),  ore('circuitLv'), metaitem('cableGtSingleTin')],
+    [metaitem('electric.motor.lv'), metaitem('gregtech:hull.lv'), metaitem('toolHeadDrillSteel')],
+    [ore('circuitLv'), metaitem('cableGtSingleTin'), metaitem('electric.piston.lv')]
+])
+
 // crafting.addShaped("rubber_rod_manual", metaitem('stickRubber'), [
 //     [ore('craftingToolFile'), null, null],
 //     [null, ore('ingotRubber'), null],


### PR DESCRIPTION
## What
Made Lv Lathe recipe use a steel drill head instead of a diamond.

## Implementation Details
replaced the recipe for the Lv Lathe and made it use a steel drill head.

## Outcome
Diamond is no longer required for the Lv Lathe.

## Additional Information
Has been tested 