### PR TITLE
Lv Macerator recipe change

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -124,6 +124,12 @@ crafting.replaceShaped("gregtech:gregtech.machine.lathe.lv", metaitem('gregtech:
     [ore('circuitLv'), metaitem('cableGtSingleTin'), metaitem('electric.piston.lv')]
 ])
 
+crafting.replaceShaped("gregtech:gregtech.machine.macerator.lv", metaitem('gregtech:macerator.lv'), [
+    [metaitem('electric.piston.lv'), metaitem('electric.motor.lv') , metaitem('toolHeadBuzzSawSteel')],
+    [metaitem('cableGtSingleTin'), metaitem('cableGtSingleTin'), metaitem('gregtech:hull.lv')],
+    [ore('circuitLv'), ore('circuitLv'), metaitem('cableGtSingleTin')]
+])
+
 // crafting.addShaped("rubber_rod_manual", metaitem('stickRubber'), [
 //     [ore('craftingToolFile'), null, null],
 //     [null, ore('ingotRubber'), null],


### PR DESCRIPTION

## What
Added some lines of code to fix the lv macerator needing diamonds, by swapping out the diamond with a steel buzzsaw blade.


## Implementation Details
Nah, well if anyone has any problems with the diamond being replaced with a steel buzzsaw blade lmk at FestiveHiro#4693

## Outcome
Made the lv macerator recipe need steel buzzsaw blade instead of diamond.
