### PR TITLE
Weeping angels no longer drop ender pearls

### DIFF
--- a/config/incontrol/loot.json
+++ b/config/incontrol/loot.json
@@ -1,1 +1,13 @@
-[]
+[   
+    {
+        "$or":[
+            {"mob":"weeping-angels:angel_0"},
+            {"mob":"weeping-angels:angel_1"},
+            {"mob":"weeping-angels:angel_2"},
+            {"mob":"weeping-angels:angel_3"},
+            {"mob":"weeping-angels:angel_4"},
+            {"mob":"weeping-angels:angel_child"}
+        ],
+        "remove":"minecraft:ender_pearl"
+    }
+]


### PR DESCRIPTION
## What
- InControl was used to modify mob drops in a very simple and non-jank way
- All weeping angel variants no longer drop ender pearls