### PR TITLE
New primitive steel durations

### DIFF
--- a/groovy/postInit/chains/IronChain.groovy
+++ b/groovy/postInit/chains/IronChain.groovy
@@ -163,7 +163,7 @@ for (combustible in combustibles) {
     .inputs(ore(combustible.name) * combustible.amount_required)
     .outputs(metaitem('ingotSteel'))
     .outputs(metaitem(combustible.byproduct) * combustible.amount_required)
-    .duration(combustible.duration * 160)
+    .duration(combustible.duration * 120)
     .buildAndRegister()
 
     PBF_RECIPES.recipeBuilder()
@@ -171,7 +171,7 @@ for (combustible in combustibles) {
     .inputs(ore(combustible.name) * combustible.amount_required)
     .outputs(metaitem('ingotSteel'))
     .outputs(metaitem(combustible.byproduct) * combustible.amount_required)
-    .duration(combustible.duration * 120)
+    .duration(combustible.duration * 60)
     .buildAndRegister()
 }
 


### PR DESCRIPTION
## What
This PR changes the primitive steel recipe durations. With these changes, 1 PBF for smelting ore and 1 PBF for making steel will have no bottlenecks in throughput. The smelting durations are also lower now, which makes early-game steel production easier.

## Outcome
Rebalances primitive steel durations.
