### PR TITLE
Add itemphysic full

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,11 @@
       "required": true
     },
     {
+      "projectID": 258587,
+      "fileID": 3487676,
+      "required": true
+    },
+    {
       "projectID": 274782,
       "fileID": 2483769,
       "required": true


### PR DESCRIPTION
## What
prevents inflammable objects from being destroyed in lava
makes buoyant objects float on water
alloys players to throw stuff with varying strength
cactus is no longer a black hole of destroying items
