### PR TITLE
Add a zombie and bandit invasion.

### DIFF
--- a/config/onslaught/onslaught.cfg
+++ b/config/onslaught/onslaught.cfg
@@ -1,0 +1,408 @@
+# Configuration file
+
+general {
+
+    debug {
+        B:INVASION_COMMANDS=false
+        B:INVASION_DATA_UPDATES=false
+        B:INVASION_SELECTOR=false
+        B:INVASION_SPAWNERS=false
+        B:INVASION_SPAWN_SAMPLER=false
+        B:INVASION_STATE=false
+    }
+
+    client {
+        # RGB color of the invasion HUD progress bars.
+        # Default: [0, 0, 255]
+        # Min: 0
+        # Max: 255
+        I:INVASION_HUD_BAR_COLOR_RGB <
+            0
+            0
+            255
+         >
+
+        # Width of the invasion HUD progress bars.
+        # Default: 128
+        I:INVASION_HUD_BAR_WIDTH=128
+
+        # XY position of the invasion HUD.
+        # Default: [16, 16]
+        I:INVASION_HUD_POSITION_XY <
+            16
+            16
+         >
+
+        # Displays active invasions of player within this block range.
+        # A chunk is 16 blocks.
+        # Default: 128
+        I:INVASION_HUD_UPDATE_RANGE=128
+    }
+
+    invasion {
+        # This is the name of the default invasion that will be selected if no
+        # invasion qualifies for a player. This invasion's selection qualifiers
+        # will be ignored. If this is blank and no invasion qualifies for a player,
+        # no invasion will occur for said player.
+        # Default: 
+        S:DEFAULT_FALLBACK_INVASION=
+
+        # The default invasion start message sent to the player.
+        # Can be a string or lang key.
+        # Set to an empty string to disable.
+        # Default: message.onslaught.invasion.begin
+        S:DEFAULT_MESSAGE_BEGIN=message.onslaught.invasion.begin
+
+        # The default invasion end message sent to the player.
+        # Can be a string or lang key.
+        # Set to an empty string to disable.
+        # Default: message.onslaught.invasion.end
+        S:DEFAULT_MESSAGE_END=message.onslaught.invasion.end
+
+        # The default warning message sent to the player.
+        # Can be a string or lang key.
+        # Default: message.onslaught.invasion.warn
+        S:DEFAULT_MESSAGE_WARNING=message.onslaught.invasion.warn
+
+        # The number of ticks prior to the invasion that the warning message
+        # will be sent.
+        # Set to -1 to disable.
+        # Default: -1
+        I:DEFAULT_MESSAGE_WARNING_TICKS=-1
+
+        # The number of ticks to delay the forced spawns.
+        # Default: 200
+        I:FORCED_SPAWN_DELAY_TICKS=200
+
+        # Effect id's of effects to be applied when a player is near a forced
+        # spawn location. These effects will be continuously applied while a
+        # player is within range.
+        S:FORCED_SPAWN_EFFECTS <
+            minecraft:slowness
+         >
+
+        # Duration of effects applied when a player is within range of a forced
+        # spawn location.
+        # Default: 200
+        I:FORCED_SPAWN_EFFECT_DURATION_TICKS=200
+
+        # If a player is within this range of a forced spawn location, the forced
+        # spawn effects will be applied.
+        # Default: 16
+        I:FORCED_SPAWN_EFFECT_RANGE=16
+
+        # The maximum number of invasions that can occur at the same time.
+        # Default: 5
+        I:MAX_CONCURRENT_INVASIONS=5
+
+        # Duration in ticks that a player can be offline before their invasion
+        # mobs are stripped of invasion data.
+        # Default: 2400
+        I:OFFLINE_CLEANUP_DELAY_TICKS=2400
+
+        # The min and max number of ticks before a player becomes eligible for an invasion.
+        # For reference, a Minecraft day is 24000 ticks long.
+        # Default: [120000, 168000] or 5-7 Minecraft days
+        I:TIMING_RANGE_TICKS <
+            120000
+            168000
+         >
+    }
+
+    wave {
+        B:DEFAULT_FORCE_SPAWN=true
+        S:DEFAULT_SECONDARY_MOB_ID=
+
+        default_spawn {
+            # The default light range.
+            # Min: 0
+            # Max: 15
+            I:DEFAULT_LIGHT <
+                0
+                7
+             >
+
+            # The default minimum and maximum spawn range.
+            # Min: 0
+            # Max: 2147483647
+            I:DEFAULT_RANGE_XZ <
+                16
+                128
+             >
+
+            # The default vertical spawn range.
+            # Min: 0
+            # Max: 2147483647
+            I:DEFAULT_RANGE_Y=16
+
+            # The default spawn sample distance.
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_SAMPLE_DISTANCE=2
+
+            # The default spawn range step radius.
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_STEP_RADIUS=4
+
+            # The default spawn type.
+            # Valid values:
+            # ground
+            # air
+            # beneath
+            S:DEFAULT_TYPE=ground
+        }
+
+        default_secondary_spawn {
+            # The default light range.
+            # Min: 0
+            # Max: 15
+            I:DEFAULT_LIGHT <
+                0
+                15
+             >
+
+            # The default minimum and maximum spawn range.
+            # Min: 0
+            # Max: 2147483647
+            I:DEFAULT_RANGE_XZ <
+                16
+                128
+             >
+
+            # The default vertical spawn range.
+            # Min: 0
+            # Max: 2147483647
+            I:DEFAULT_RANGE_Y=16
+
+            # The default spawn sample distance.
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_SAMPLE_DISTANCE=2
+
+            # The default spawn range step radius.
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_STEP_RADIUS=4
+
+            # The default spawn type.
+            # Valid values:
+            # ground
+            # air
+            # beneath
+            S:DEFAULT_TYPE=air
+        }
+
+    }
+
+    custom_ai {
+
+        anti_air {
+            # If true, the force applied from all nearby AntiAir mobs will be summed
+            # before application. If false, only the greatest force from all nearby
+            # AntiAir mobs will be applied.
+            # Default: false
+            B:CUMULATIVE_MOTION_Y=false
+
+            # The default Y motion value applied to the mob's target.
+            # Can be overridden in a mob template or with NBT.
+            # Default: -0.4
+            # Min: -2147483648
+            # Max: 0
+            D:DEFAULT_MOTION_Y=-0.4
+
+            # The default range at which a mob will pull its target down.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 128
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_RANGE=128
+
+            # Set to true to require line of sight with target.
+            # Can be overridden in a mob template or with NBT.
+            # Default: true
+            B:DEFAULT_SIGHT_REQUIRED=true
+
+            # The number of ticks that the player is allowed to be in the air
+            # before they are pulled down.
+            # Default: 15
+            # Min: 0
+            # Max: 2147483647
+            I:DELAY_TICKS=15
+        }
+
+        lunge {
+            # The default range at which a mob will increase its speed.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 6
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_RANGE=6
+
+            # The default speed modifier used.
+            # For reference, the sprint speed modifier is 0.3.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 0.3
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_SPEED_MODIFIER=0.3
+        }
+
+        explode_when_stuck {
+            # Set to true to cause the explosion to start fires.
+            # Can be overridden in a mob template or with NBT.
+            # Default: false
+            B:DEFAULT_EXPLOSION_CAUSES_FIRE=false
+
+            # Set to false to cause the explosion to be harmless.
+            # Can be overridden in a mob template or with NBT.
+            # Default: true
+            B:DEFAULT_EXPLOSION_DAMAGING=true
+
+            # The default explosion delay.
+            # How long the mob can be stuck before it explodes.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 60
+            # Min: 0
+            # Max: 2147483647
+            I:DEFAULT_EXPLOSION_DELAY_TICKS=60
+
+            # The default explosion strength.
+            # For reference, an uncharged creeper has an explosion strength of 3
+            # and a charged creeper has an explosion strength of 6.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 3
+            # Min: 1
+            # Max: 2147483647
+            D:DEFAULT_EXPLOSION_STRENGTH=3.0
+
+            # The default target range to allow the mob to explode.
+            # Can be overridden in a mob template or with NBT.
+            # Default: [2, 16]
+            D:DEFAULT_RANGE <
+                2.0
+                16.0
+             >
+
+            # Set to false to ignore the range to target.
+            # Can be overridden in a mob template or with NBT.
+            # Default: true
+            B:DEFAULT_RANGE_REQUIRED=true
+
+            # Set to true to require line of sight with target.
+            # Can be overridden in a mob template or with NBT.
+            # Default: false
+            B:DEFAULT_SIGHT_REQUIRED=false
+        }
+
+        counter_attack {
+            # The default chance of counter attacking.
+            # For reference, the spider's leap chance is 0.25.
+            # Note: The chance will not prevent the task from executing,
+            # but it may delay, or at least vary, the timing of the execution.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 0.25
+            # Min: 0.0
+            # Max: 1.0
+            D:DEFAULT_CHANCE=0.25
+
+            # The default XZ motion value when counter attacking.
+            # For reference the spider's XZ leap motion value is 0.4
+            # Can be overridden in a mob template or with NBT.
+            # Default: 0.4
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_LEAP_MOTION_XZ=0.4
+
+            # The default Y motion value when counter attacking.
+            # For reference the spider's Y leap motion value is 0.4
+            # Can be overridden in a mob template or with NBT.
+            # Default: 0.4
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_LEAP_MOTION_Y=0.4
+
+            # The default range for allowing a counter attack.
+            # For reference the spider's leap range is [2,4].
+            # Can be overridden in a mob template or with NBT.
+            # Default: [2, 4]
+            D:DEFAULT_RANGE <
+                2.0
+                4.0
+             >
+        }
+
+        attack_melee {
+            # The default attack damage.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 1
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_ATTACK_DAMAGE=1.0
+
+            # The default movement speed when attacking.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 1
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_SPEED=1.0
+        }
+
+        long_distance_chase {
+            # The default long distance chase speed.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 1
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_SPEED=1.0
+        }
+
+        mining {
+            # The default mining range used.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 4
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_RANGE=4
+
+            # The default mining speed modifier used.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 1
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:DEFAULT_SPEED_MODIFIER=1.0
+
+            # The ablity for mobs to be able to mine blocks without requiring the necessary tool level.
+            # Default: true
+            B:MINE_WITHOUT_REQUIRED_TOOL=true
+        }
+
+        "offscreen teleport" {
+            # The default ability to teleport across dimensions to chase the target
+            # Can be overridden in a mob template or with NBT.
+            # Default: true
+            B:DEFAULT_DIM_HOPPING=true
+
+            # The default teleportation factor to 'move closer' to the target.
+            # 0.5 => move half the distance
+            # 1.0 => move directly on top of target
+            # 1.5 => move to the target, then half again to flank the target.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 1.5
+            # Min: 0.0
+            # Max: 2.0
+            D:DEFAULT_FACTOR=1.5
+
+            # The default offscreen teleport range for mobs to trigger a relocate.
+            # Can be overridden in a mob template or with NBT.
+            # Default: 64
+            # Min: 1
+            # Max: 2147483647
+            I:DEFAULT_RANGE=64
+        }
+
+    }
+
+}
+
+

--- a/config/onslaught/templates/invasion/bandit_invasion.json
+++ b/config/onslaught/templates/invasion/bandit_invasion.json
@@ -1,0 +1,79 @@
+{
+  "bandit_invasion": {
+    "name": "Bandit Invasion",
+    "selector": {
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      },
+	    "weight": 50
+    },
+    "earlyEnd": {
+		"maxInvasionDuration": 600,
+		"message": "The bandits got bored and scattered..."
+    },
+    "messages": {
+      "start": "Bandits appear!",
+      "end": "The threat has been neutralized."
+    },
+     "waves": [
+      {
+        "delayTicks": [0],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "bandit",
+                "count": [1, 2],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 7],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "delayTicks": [1000, 1500],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "bandit_reinforcement_00",
+                "count": [3, 4],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 15],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          },
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "bandit_reinforcement_01",
+                "count": [3, 4],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 15],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          }
+        ]
+      }
+	]
+  }
+}

--- a/config/onslaught/templates/invasion/bandit_invasion.json
+++ b/config/onslaught/templates/invasion/bandit_invasion.json
@@ -28,10 +28,10 @@
             "mobs": [
               {
                 "id": "bandit",
-                "count": [1, 2],
+                "count": [2, 3],
                 "spawn": {
                   "type": "ground",
-                  "light": [0, 7],
+                  "light": [0, 15],
                   "rangeXZ": [16, 32]
                 }
               }

--- a/config/onslaught/templates/invasion/zombie_horde.json
+++ b/config/onslaught/templates/invasion/zombie_horde.json
@@ -1,0 +1,79 @@
+{
+  "zombie_horde": {
+    "name": "Zombie Invasion",
+    "selector": {
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      },
+	    "weight": 50
+    },
+    "earlyEnd": {
+		"maxInvasionDuration": 600,
+		"message": "The zombie horde got bored and scattered..."
+    },
+    "messages": {
+      "start": "Zombies appear!",
+      "end": "The threat has been neutralized."
+    },
+     "waves": [
+      {
+        "delayTicks": [0],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "zombie",
+                "count": [4, 8],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 7],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "delayTicks": [1000, 1500],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "zombie_reinforcement_00",
+                "count": [6, 10],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 15],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          },
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "zombie_reinforcement_01",
+                "count": [6, 10],
+                "spawn": {
+                  "type": "ground",
+                  "light": [0, 15],
+                  "rangeXZ": [16, 32]
+                }
+              }
+            ]
+          }
+        ]
+      }
+	]
+  }
+}

--- a/config/onslaught/templates/invasion/zombie_horde.json
+++ b/config/onslaught/templates/invasion/zombie_horde.json
@@ -28,7 +28,7 @@
             "mobs": [
               {
                 "id": "zombie",
-                "count": [4, 8],
+                "count": [8, 12],
                 "spawn": {
                   "type": "ground",
                   "light": [0, 7],
@@ -47,8 +47,8 @@
             "forceSpawn": true,
             "mobs": [
               {
-                "id": "zombie_reinforcement_00",
-                "count": [6, 10],
+                "id": "zombie",
+                "count": [8, 12],
                 "spawn": {
                   "type": "ground",
                   "light": [0, 15],
@@ -62,8 +62,8 @@
             "forceSpawn": true,
             "mobs": [
               {
-                "id": "zombie_reinforcement_01",
-                "count": [6, 10],
+                "id": "zombie",
+                "count": [8, 12],
                 "spawn": {
                   "type": "ground",
                   "light": [0, 15],

--- a/config/onslaught/templates/mob/bandits.json
+++ b/config/onslaught/templates/mob/bandits.json
@@ -1,0 +1,34 @@
+{
+  "bandit": {
+    "id": "techguns:bandit"
+  },
+  "bandit_reinforcement_00": {
+    "id": "techguns:bandit",
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "CounterAttack": { "Chance": 0.5 }
+          }
+        }
+      }
+    },
+  "bandit_reinforcement_01": {
+    "id": "techguns:bandit",
+    "nbt": {
+      "ArmorItems": [
+        { "Count": 1, "id": "minecraft:leather_boots" },
+        { "Count": 1, "id": "minecraft:leather_leggings" },
+        { "Count": 1, "id": "minecraft:leather_chestplate" },
+        { "Count": 1, "id": "minecraft:leather_helmet" }
+      ],
+      "ArmorDropChances": [0.0, 0.0, 0.0, 0.0],
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "Lunge": { "Range": 6, "SpeedModifier": 0.3 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/onslaught/templates/mob/zombies.json
+++ b/config/onslaught/templates/mob/zombies.json
@@ -1,0 +1,18 @@
+{
+  "zombie": {
+    "id": "minecraft:zombie"
+  },
+  "zombie_reinforcement_00": {
+    "id": "techguns:zombieminer",
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "CounterAttack": { "Chance": 0.2 }
+          }
+        }
+      }
+  },
+  "zombie_reinforcement_01": {
+    "id": "techguns:zombiesoldier"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,11 @@
       "fileID": 2830114,
       "required": true
     },
+	{
+      "projectID": 433235,
+      "fileID": 3873356,
+      "required": true
+    },
     {
       "projectID": 650242,
       "fileID": 4445251,


### PR DESCRIPTION
## DONT MERGE BEFORE TESTING (this is spammed so that 3 AM Gaming can understand)
## DONT MERGE BEFORE TESTING (this is spammed so that 3 AM Gaming can understand)
## DONT MERGE BEFORE TESTING (this is spammed so that 3 AM Gaming can understand)
## DONT MERGE BEFORE TESTING (this is spammed so that 3 AM Gaming can understand)
Adds the Onslaught mod.
Players are eligible for invasion after having played 500k to 600k ticks (should be about 8-10h)

Zombie invasion: has 2 waves, one spawns normal zombies, the other spawns zombie miners and zombie soldiers
Bandit invasion: has 2 waves, one spawns 2 normal bandits, the other spawns bandits that can counterattack and bandits that have armor

Should be tested first by other players to see if it's too hard (use steam/ LV gear)