### PR TITLE
Epic BetterParties update (real)

### DIFF
--- a/config/betterparties.cfg
+++ b/config/betterparties.cfg
@@ -1,0 +1,21 @@
+# Configuration file
+
+general {
+    # Quest completion is shared between team members
+    B:"Shared Completion"=true
+
+    # Once any team member claimed a reward, it is claimed for others
+    B:"Shared Rewards"=false
+
+    # Adds `/party_sync` to forcefully sync quests with all members
+    # WARNING: If your intent is to disallow syncing to new team members,
+    # set `Sync On Join` to false too, or else this change would be useless!
+    B:"Sync Command"=true
+
+    # Synchronizes quests with team members on player joining to a party
+    # WARNING: If your intent is to disallow syncing to new team members,
+    # set `Sync Command` to false too, or else this change would be useless!
+    B:"Sync On Join"=true
+}
+
+

--- a/manifest.json
+++ b/manifest.json
@@ -919,6 +919,11 @@
       "projectID": 870211,
       "fileID": 4567593,
       "required": true
+    },
+    {
+      "projectID": 880959,
+      "fileID": 4610305,
+      "required": true
     }
   ],
   "overrides": "overrides"


### PR DESCRIPTION
## What
Adds BetterParties mod to fix quest syncing in BQ parties because the dev thought it would be funny:
> Party progress sharing is getting changed to disallow "sling-shotting" progress of players joining a party. **This means that existing party members will be able to assist new members but they won't inherit progression without an OP forcing such a sync.**

> That's because I changed it intentionally. People were exploiting it and freeloading off their parties while solo players got screwed over. This was my solution.

> Party share was changed specifically to stop people freeloading or submitting less resources per-player than those going solo. **If someone was offline and didn't get the progress then yes, the system is working as intended.**

I'm not completely sure if this is an issue in BQu, but some people report it: CleanroomMC/BetterQuesting#81

## Implementation Details
Nothing much, this mod of mine has a config and you can tweak it to your heart's content.

## Outcome
Fixes party syncing (for example, if a team member was offline while epic gaming was happening, he would get desynced)
