### PR TITLE
Onslaught Fixes

### DIFF
--- a/config/onslaught/onslaught.cfg
+++ b/config/onslaught/onslaught.cfg
@@ -29,8 +29,8 @@ general {
         # XY position of the invasion HUD.
         # Default: [16, 16]
         I:INVASION_HUD_POSITION_XY <
-            16
-            16
+            416
+            56
          >
 
         # Displays active invasions of player within this block range.
@@ -133,7 +133,7 @@ general {
             # The default vertical spawn range.
             # Min: 0
             # Max: 2147483647
-            I:DEFAULT_RANGE_Y=16
+            I:DEFAULT_RANGE_Y=8
 
             # The default spawn sample distance.
             # Min: 1

--- a/config/onslaught/templates/mob/zombies.json
+++ b/config/onslaught/templates/mob/zombies.json
@@ -1,18 +1,13 @@
 {
-  "zombie": {
-    "id": "minecraft:zombie"
-  },
-  "zombie_reinforcement_00": {
-    "id": "techguns:zombieminer",
-      "ForgeData": {
-        "Onslaught": {
-          "CustomAI": {
-            "CounterAttack": { "Chance": 0.2 }
-          }
-        }
-      }
-  },
-  "zombie_reinforcement_01": {
-    "id": "techguns:zombiesoldier"
-  }
+	"zombie": {
+		"id": "minecraft:zombie",
+		"effects": [
+			{
+				"id": "minecraft:speed",
+				"duration": 2400,
+				"amplifier": 1,
+				"showParticles": false
+			}
+		]
+	}
 }


### PR DESCRIPTION

## What
Correctly positioned invasion progress bar atop the screen, previously covered by the info in the top left.
Decreased default +/- Y range for spawning during invasions, hopefully decreasing the amount of mobs spawning in caves and getting lost by players.
Removed unused Zombie variants, at Regians request.
Increased default Zombie speed, at Regians request.

## Implementation Details
Changed general Onslaught Config
Changed Onslaught Mob Zombies Template
