### PR TITLE
Update GTCEu to 2.7.0, GTFO to 1.9.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -167,7 +167,7 @@
     },
     {
       "projectID": 557242,
-      "fileID": 4527757,
+      "fileID": 4637703,
       "required": true
     },
     {
@@ -337,7 +337,7 @@
     },
     {
       "projectID": 477021,
-      "fileID": 4555292,
+      "fileID": 4637716,
       "required": true
     },
     {


### PR DESCRIPTION
## DONT MERGE YET IT CRASHES THE GAME
@Tech22 [22:34:00] [main/ERROR] [LaunchWrapper]: Unable to launch
java.lang.RuntimeException: An error occurred trying to configure the Minecraft home at C:\Users\gatto\AppData\Roaming\PrismLauncher\instances\Supersymmetry\minecraft for Forge Mod Loader
