### PR TITLE
Add computronics back

### DIFF
--- a/config/mod-director/computronics.url.json
+++ b/config/mod-director/computronics.url.json
@@ -1,0 +1,3 @@
+{
+  "url": "https://cdn.sussy.dev/minecraft/computronics.jar"
+}


### PR DESCRIPTION
## What
Now with a sexy permanent jiafei link (cached by Cloudflare CDN indefinitely)

## Implementation Details
The Sussy Development Inc.:tm: now hosts Computronics as Vexatos sucks at his sysadmin job (real)

## Outcome
No more issues with computronics ever again (I will notify you if we will have to migrate to new infrastructure later)

## Additional Information
Vexatos really sucks at doing basic sysadmin jobs man I want to hunt him down and commit arson for his bad nginx work :rage: 

## Potential Compatibility Issues
None
