### PR TITLE
Update Fluidlogged API to v2.2.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -122,7 +122,7 @@
     },
     {
       "projectID": 485654,
-      "fileID": 4430381,
+      "fileID": 4564413,
       "required": true
     },
     {


### PR DESCRIPTION
Allows Industrial Renewal Storage Racks to be placed properly, along with a host of other fixes.
I did check that this version actually launches properly with the pack, so it should be fine.