### PR TITLE
Update WTF and actually let floppas spawn

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -30,6 +30,15 @@
   },
   {
 	"dimension": 0,
+	"mod": "caracalsmod",
+	"maxcount": {
+		"amount": 4,
+		"perplayer": true
+	},
+	"result": "default"
+  },
+  {
+	"dimension": 0,
 	"mob": [
 		"minecraft:zombie"
 	],

--- a/manifest.json
+++ b/manifest.json
@@ -142,7 +142,7 @@
     },
     {
       "projectID": 870211,
-      "fileID": 4567593,
+      "fileID": 4648785,
       "required": true
     },
     {


### PR DESCRIPTION
First, this fixes a server crash with WTF 1.0.0. Secondly, this changes the InControl configuration to actually allow floppas to spawn now.