### PR TITLE
Make mozzarella obtainable

### DIFF
--- a/groovy/postInit/mod/GregTechFoodOption.groovy
+++ b/groovy/postInit/mod/GregTechFoodOption.groovy
@@ -467,6 +467,24 @@ LCR.recipeBuilder()
         .duration(240)
         .EUt(120)
         .buildAndRegister()
+
+// Replace mozzarella recipes to make it obtainable
+ROASTER.recipeBuilder()
+        .inputs(metaitem('dried_mozzarella_curd_nugget'))
+        .outputs(metaitem('solidified_mozzarella_curd_nugget'))
+        .fluidOutputs(fluid('gtfo_whey') * 50)
+        .duration(200)
+        .EUt(16)
+        .buildAndRegister()
+		
+MIXER.recipeBuilder()
+        .fluidInputs(fluid('milk') * 6000)
+        .fluidInputs(fluid('gtfo_crude_rennet_solution'))
+        .fluidInputs(fluid('gtfo_whey') * 400)
+        .outputs(metaitem('large_mozzarella_curd_nugget'))
+        .duration(160)
+        .EUt(8)
+        .buildAndRegister()
 		
 // Force GTFO skewers to be made with only long rods
 // Skewer * 16


### PR DESCRIPTION
## What
This fixes the solidified curd recipe and removes the dependency on italian buffalo, which currently do not spawn.

## Implementation Details
Please make sure that these recipes work and that I'm not screwing things up again.

## Outcome
Makes mozzarella and its derivative foods obtainable.

## Additional Information
![image](https://github.com/SymmetricDevs/Supersymmetry/assets/80226372/3bf09a81-0b2e-4e22-9e50-40006e3bb584)

