### PR TITLE
Lower spawn rates and remove speed effects

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -32,7 +32,7 @@
 	"dimension": 0,
 	"mod": "caracalsmod",
 	"maxcount": {
-		"amount": 4,
+		"amount": 1,
 		"perplayer": true
 	},
 	"result": "default"
@@ -46,26 +46,24 @@
 	"maxtime": 23999,
 	"seesky": true,
 	"maxcount": {
-		"amount": 5,
+		"amount": 2,
 		"perplayer": true
 	},
 	"result": "default",
-	"speedmultiply": 2.5,
-	"damagemultiply": 2,
+	"damagemultiply": 3,
 	"angry": true
   },
-    {
+  {
 	"dimension": 0,
 	"mob": [
 		"techguns:outcast"
 	],
 	"spawner": true,
 	"maxcount": {
-		"amount": 4,
+		"amount": 2,
 		"perplayer": true
 	},
 	"result": "default",
-	"speedmultiply": 1.5,
 	"angry": true
   },
   {
@@ -84,7 +82,7 @@
 		"weeping-angels:weepingangel"
 	],
 	"maxcount": {
-		"amount": 3,
+		"amount": 1,
 		"perplayer": true
 	},
 	"result": "default"

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -21,15 +21,6 @@
   },
   {
 	"dimension": 0,
-	"mod": "betteranimalsplus",
-	"maxcount": {
-		"amount": 4,
-		"perplayer": true
-	},
-	"result": "default"
-  },
-  {
-	"dimension": 0,
 	"mod": "caracalsmod",
 	"maxcount": {
 		"amount": 1,


### PR DESCRIPTION
Given how lag-inducing mob spawns can get (and especially their speed effects), it seems to make the most sense to remove speed for the time being. I have slightly buffed zombie damage to somewhat correct for this.

## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->

## Implementation Details
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->

## Additional Information
<!--This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of.-->

## Potential Compatibility Issues
<!--This section is for defining possible compatibility issues. It must be used when there item/block/material/machine changes, or recipe changes.-->

<!--**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**-->
