### PR TITLE
Prevent undesired entities from spawning

### DIFF
--- a/config/incontrol/potentialspawn.json
+++ b/config/incontrol/potentialspawn.json
@@ -1,11 +1,18 @@
 [
 	{
-		"remove": "Bat"
+		"dimension": 0,
+		"remove": [
+			"Creeper",
+			"Spider",
+			"minecraft:cave_spider"
+		]
 	},
 	{
-		"remove": "Skeleton"
-	},
-	{
-		"remove": "Enderman"
+		"remove": [
+			"Bat",
+			"Skeleton",
+			"Enderman",
+			"Squid"
+		]
 	}
 ]

--- a/config/incontrol/potentialspawn.json
+++ b/config/incontrol/potentialspawn.json
@@ -1,1 +1,11 @@
-[]
+[
+	{
+		"remove": "Bat"
+	},
+	{
+		"remove": "Skeleton"
+	},
+	{
+		"remove": "Enderman"
+	}
+]


### PR DESCRIPTION
## What
Some mobs that should not try to spawn are still trying to. This prevents that

## Implementation Details
Simple edit of the InControl configs

## Outcome
Those entities won't try to spawn anymore
