### PR TITLE
Add rock breaker recipes back

### DIFF
--- a/groovy/prePostInit/WipeRecipeMaps.groovy
+++ b/groovy/prePostInit/WipeRecipeMaps.groovy
@@ -19,9 +19,6 @@ removeAllRecipes(GTFORecipeMaps.GREENHOUSE_RECIPES);
 removeAllRecipes(RecipeMaps.VACUUM_RECIPES);
 removeAllRecipes(RecipeMaps.ELECTROLYZER_RECIPES);
 
-//Removed due to infinite stone being unrealistic
-removeAllRecipes(recipemap('rock_breaker'));
-
 //Removal of certain centrifuging recipes
 
 // LPG * 370


### PR DESCRIPTION
Given that we already have infinite ores and that you can get an infinite cobble generator already through a block breaker, this doesn't really matter.
