### PR TITLE
Add lignite processing

### DIFF
--- a/groovy/globals/Globals.groovy
+++ b/groovy/globals/Globals.groovy
@@ -48,6 +48,8 @@ class Globals {
     public static combustibles = [
         new Combustible('gemCoke', 1, 3, 'dustTinyAsh'),
         new Combustible('dustCoke', 1, 3, 'dustTinyAsh'),
+        new Combustible('gemLigniteCoke', 2, 4, 'dustTinyAsh'),
+        new Combustible('dustLigniteCoke', 2, 4, 'dustTinyAsh'),
         new Combustible('gemAnthracite', 1, 2, 'dustTinyAsh'),
         new Combustible('dustAnthracite', 1, 2, 'dustTinyAsh'),
         new Combustible('gemCoal', 2, 4, 'dustTinyDarkAsh'),

--- a/groovy/material/OreMaterials.groovy
+++ b/groovy/material/OreMaterials.groovy
@@ -273,7 +273,7 @@ public class OreMaterials{
                 .build();
 
         Lignite = new Material.Builder(7033, SuSyUtility.susyId('lignite'))
-                .gem(1, 534).ore(2, 1)
+                .gem(1, 600).ore(2, 1)
                 .color(0x644646).iconSet(LIGNITE)
                 .components(Carbon, 1)
                 .flags(FLAMMABLE, NO_SMELTING, NO_SMASHING, MORTAR_GRINDABLE)

--- a/groovy/material/OreMaterials.groovy
+++ b/groovy/material/OreMaterials.groovy
@@ -273,7 +273,7 @@ public class OreMaterials{
                 .build();
 
         Lignite = new Material.Builder(7033, SuSyUtility.susyId('lignite'))
-                .gem(1, 1200).ore(2, 1)
+                .gem(1, 534).ore(2, 1)
                 .color(0x644646).iconSet(LIGNITE)
                 .components(Carbon, 1)
                 .flags(FLAMMABLE, NO_SMELTING, NO_SMASHING, MORTAR_GRINDABLE)
@@ -563,5 +563,13 @@ public class OreMaterials{
                 .components(Platinum, 1)
                 .colorAverage()
                 .build();
+
+        LigniteCoke = new Material.Builder(7075, SuSyUtility.susyId('lignite_coke'))
+                .gem(1, 1200)
+                .color(0x8f7070).iconSet(LIGNITE)
+                .components(Carbon, 1)
+                .flags(FLAMMABLE, NO_SMELTING, NO_SMASHING, MORTAR_GRINDABLE)
+                .build();
+
     }
 }

--- a/groovy/material/SuSyMaterials.groovy
+++ b/groovy/material/SuSyMaterials.groovy
@@ -65,6 +65,7 @@ class SuSyMaterials {
         public static Material Crookesite;
         public static Material Dilithium;
         public static Material Lignite;
+        public static Material LigniteCoke;
         public static Material Anthracite;
         public static Material Acanthite;
         public static Material Phosphorite;

--- a/groovy/postInit/chemistry/organic_chemistry/CoalPyrolysisChain.groovy
+++ b/groovy/postInit/chemistry/organic_chemistry/CoalPyrolysisChain.groovy
@@ -29,7 +29,7 @@ PYROLYSE_OVEN.recipeBuilder()
         .duration(320)
         .EUt(60)
         .buildAndRegister()
-        
+
 PYROLYSE_OVEN.recipeBuilder()
         .inputs(ore('gemAnthracite') * 16)
         .outputs(metaitem('gemCoke') * 14)
@@ -178,4 +178,59 @@ DISTILLATION_TOWER.recipeBuilder()
         .fluidOutputs(fluid('naphthalene_oil') * 200)
         .duration(200)
         .EUt(48)
+        .buildAndRegister()
+
+// Lignite processing
+
+//----- Lignite pyrolysis to Lignite Coke
+PYROLYSE_OVEN.recipeBuilder()
+        .inputs(ore('gemLignite') * 16)
+        .outputs(metaitem('gemLigniteCoke') * 4)
+        .fluidOutputs(fluid('creosote') * 2000)
+        .fluidOutputs(fluid('syngas') * 3200)
+        .duration(320)
+        .EUt(60)
+        .buildAndRegister()
+
+PYROLYSE_OVEN.recipeBuilder()
+        .inputs(ore('dustLignite') * 16)
+        .outputs(metaitem('dustLigniteCoke') * 4)
+        .fluidOutputs(fluid('creosote') * 2000)
+        .fluidOutputs(fluid('syngas') * 3200)
+        .duration(320)
+        .EUt(60)
+        .buildAndRegister()
+
+//----- Lignite Coke pyrolysis
+PYROLYSE_OVEN.recipeBuilder()
+        .inputs(ore('gemLigniteCoke') * 16)
+        .outputs(metaitem('dustCarbon') * 9)
+        .fluidInputs(fluid('steam') * 15000)
+        .fluidOutputs(fluid('syngas') * 12000)
+        .duration(320)
+        .EUt(60)
+        .buildAndRegister()
+
+PYROLYSE_OVEN.recipeBuilder()
+        .inputs(ore('dustLigniteCoke') * 16)
+        .outputs(metaitem('dustCarbon') * 9)
+        .fluidInputs(fluid('steam') * 15000)
+        .fluidOutputs(fluid('syngas') * 12000)
+        .duration(320)
+        .EUt(60)
+        .buildAndRegister()
+
+//----- Centrifuging to Carbon
+CENTRIFUGE.recipeBuilder()
+        .inputs(ore('dustLignite'))
+        .chancedOutput(metaitem('dustCarbon'), 2500, 0)
+        .duration(80)
+        .EUt(30)
+        .buildAndRegister()
+
+CENTRIFUGE.recipeBuilder()
+        .inputs(ore('dustLigniteCoke'))
+        .chancedOutput(metaitem('dustCarbon'), 7500, 0)
+        .duration(80)
+        .EUt(30)
         .buildAndRegister()

--- a/resources/langfiles/lang/en_us.lang
+++ b/resources/langfiles/lang/en_us.lang
@@ -1118,6 +1118,7 @@ susy.material.hutchinsonite=Hutchinsonite
 susy.material.crookesite=Crookesite
 susy.material.dilithium=Dilithium
 susy.material.lignite=Lignite
+susy.material.lignite_coke=Lignite Coke
 susy.material.anthracite=Anthracite
 susy.material.phosphorite=Phosphorite
 susy.material.sperrylite=Sperrylite


### PR DESCRIPTION
## What
* Add lignite [dust] pyrolysis to lignite coke, creosote and syngas
* Add lignite [coke] dust centrifuging to carbon
* Add lignite coke [dust] steam pyrolysis to carbon and syngas
* Nerf lignite fuel value

## Implementation Details
![image](https://github.com/SymmetricDevs/Supersymmetry/assets/4649497/daa7e8ea-2d38-4f2d-acb6-af64e781c78c)
* Lignite coke is equivalent to regular coal when used as combustible and has 75% carbon
* Lignite has ~25% carbon, so it's fuel value nerfed to be ~~1/3~~ 3/8 of FV of coal (75% C) instead of 3/4
* Lignite tar has much less polyaromatics than coal tar and consists mainly of phenols, so it's represented as creosote
* Lignite COG seems to have no ammonia, so it's represented as syngas