### PR TITLE
Sulfur deposit vein (requires susycore 0.1.11)

### DIFF
--- a/config/gregtech/worldgen/vein/beneath/graphite_vein.json
+++ b/config/gregtech/worldgen/vein/beneath/graphite_vein.json
@@ -1,0 +1,31 @@
+{
+  "weight": 40,
+  "density": 1,
+  "dimension_filter": ["dimension_id:10"],
+  "max_height": 255,
+  "min_height": 0,
+  "generator": {
+    "type": "layered",
+    "radius": [
+      8,
+      8
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:graphite"
+      },
+      {
+        "secondary": "ore:graphite"
+      },
+      {
+        "between": "ore:graphite"
+      },
+      {
+        "sporadic": "ore:graphite"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/graphite_vein.json
+++ b/config/gregtech/worldgen/vein/nether/graphite_vein.json
@@ -1,0 +1,33 @@
+{
+  "weight": 40,
+  "density": 1,
+  "dimension_filter":[
+        "dimension_id:-1"
+  ],
+  "max_height": 255,
+  "min_height": 0,
+  "generator": {
+    "type": "layered",
+    "radius": [
+      8,
+      8
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:graphite"
+      },
+      {
+        "secondary": "ore:graphite"
+      },
+      {
+        "between": "ore:graphite"
+      },
+      {
+        "sporadic": "ore:graphite"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/nether/sulfur_deposit_vein.json
@@ -1,6 +1,6 @@
 {
   "weight": 120,
-  "density": 1,
+  "density": 0.8,
   "dimension_filter":[
     "dimension_id:-1"
   ],
@@ -9,8 +9,8 @@
   "generator": {
     "type": "layered",
     "radius": [
-      20,
-      20
+      16,
+      16
     ]
   },
   "filler": {

--- a/config/gregtech/worldgen/vein/nether/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/nether/sulfur_deposit_vein.json
@@ -1,0 +1,45 @@
+{
+  "weight": 120,
+  "density": 1,
+  "dimension_filter":[
+    "dimension_id:-1"
+  ],
+  "max_height":120,
+  "min_height":0,
+  "generator": {
+    "type": "layered",
+    "radius": [
+      20,
+      20
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "secondary": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "between": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "sporadic": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/overworld/garnierite_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/garnierite_vein.json
@@ -1,33 +1,33 @@
 {
-  "weight": 80,
+  "weight": 60,
   "density": 0.75,
   "max_height": 80,
   "min_height": 0,
   "vein_populator": {
     "type": "surface_rock",
-    "material": "silver"
+    "material": "garnierite"
   },
   "generator": {
     "type": "layered",
     "radius": [
-      16,
-      16
+      20,
+      20
     ]
   },
   "filler": {
     "type": "layered",
     "values": [
       {
-        "primary": "ore:acanthite"
+        "primary": "ore:garnierite"
       },
       {
-        "secondary": "ore:galena"
+        "secondary": "ore:garnierite"
       },
       {
-        "between": "ore:pyrargyrite"
+        "between": "ore:garnierite"
       },
       {
-        "sporadic": "ore:silver"
+        "sporadic": "ore:garnierite"
       }
     ]
   }

--- a/config/gregtech/worldgen/vein/overworld/pentlandite_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/pentlandite_vein.json
@@ -5,29 +5,29 @@
   "min_height": 0,
   "vein_populator": {
     "type": "surface_rock",
-    "material": "silver"
+    "material": "pentlandite"
   },
   "generator": {
     "type": "layered",
     "radius": [
-      16,
-      16
+      20,
+      20
     ]
   },
   "filler": {
     "type": "layered",
     "values": [
       {
-        "primary": "ore:acanthite"
+        "primary": "ore:pentlandite"
       },
       {
-        "secondary": "ore:galena"
+        "secondary": "ore:chalcopyrite"
       },
       {
-        "between": "ore:pyrargyrite"
+        "between": "ore:pyrite"
       },
       {
-        "sporadic": "ore:silver"
+        "sporadic": "ore:pyrite"
       }
     ]
   }

--- a/config/gregtech/worldgen/vein/overworld/sulfidic_silver_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfidic_silver_vein.json
@@ -21,7 +21,7 @@
         "primary": "ore:acanthite"
       },
       {
-        "secondary": "ore:prousite"
+        "secondary": "ore:proustite"
       },
       {
         "between": "ore:pyrargyrite"

--- a/config/gregtech/worldgen/vein/overworld/sulfidic_silver_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfidic_silver_vein.json
@@ -21,7 +21,7 @@
         "primary": "ore:acanthite"
       },
       {
-        "secondary": "ore:galena"
+        "secondary": "ore:prousite"
       },
       {
         "between": "ore:pyrargyrite"

--- a/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
@@ -1,7 +1,7 @@
 {
   "weight": -1,
   "density": 0.75,
-  "max_height": 70,
+  "max_height": 110,
   "min_height": 62,
   "block": "minecraft:sand",
   "vein_populator": {
@@ -15,8 +15,8 @@
   "generator": {
     "type": "layered",
     "radius": [
-      32,
-      32
+      16,
+      16
     ]
   },
   "filler": {

--- a/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
@@ -1,7 +1,7 @@
 {
   "weight": -1,
   "density": 0.75,
-  "max_height": 110,
+  "max_height": 170,
   "min_height": 62,
   "block": "minecraft:sand",
   "vein_populator": {

--- a/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
@@ -1,0 +1,51 @@
+{
+  "weight": 120,
+  "density": 0.5,
+  "max_height": 70,
+  "min_height": 62,
+  "block": "minecraft:sand",
+  "vein_populator": {
+    "type": "surface_rock",
+    "material": "sulfur"
+  },
+  "biome_modifier": {
+    "type": "biome_map",
+    "biomesoplenty:volcanic_island": 400
+  },
+  "generator": {
+    "type": "layered",
+    "radius": [
+      32,
+      32
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "secondary": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "between": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      },
+      {
+        "sporadic": {
+          "block":"susy:resource_block",
+          "variant":"sulfur"
+        }
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
+++ b/config/gregtech/worldgen/vein/overworld/sulfur_deposit_vein.json
@@ -1,6 +1,6 @@
 {
-  "weight": 120,
-  "density": 0.5,
+  "weight": -1,
+  "density": 0.75,
   "max_height": 70,
   "min_height": 62,
   "block": "minecraft:sand",

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -668,6 +668,13 @@ mods.gregtech.macerator.recipeBuilder()
         .EUt(7)
         .buildAndRegister();
 
+mods.gregtech.macerator.recipeBuilder()
+		.inputs(item('susy:resource_block', 14))
+		.outputs(metaitem('dustSulfur') * 8)
+		.duration(240)
+		.EUt(7)
+		.buildAndRegister();
+
 mods.gregtech.sifter.recipeBuilder()
         .inputs(ore('dustNonMarineEvaporite'))
         .chancedOutput(metaitem('dustSalt'), 8000, 500)


### PR DESCRIPTION
## What
Adds : 
Graphite Vein in OW/Beneath
Sulfur Deposit Vein in volcanos and nether
Overworld Garnierite Vein
Overworld Pentlandite Vein

Modifies: 
Acanthite Vein so sporadic ore is silver instead of prousite.

Also add a recipe to macerate sulfur deposit block

Requires https://github.com/SymmetricDevs/Susy-Core/pull/173 
