### PR TITLE
Add recipes for drawer key and multiblock builder

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1373,7 +1373,7 @@ crafting.addShaped("gregtech:fluid_hatch.export.lv", metaitem('fluid_hatch.expor
 // Multiblock Builder
 
 crafting.replaceShaped("gregtech:multiblock_builder", metaitem('tool.multiblock_builder'), [
-		[ore('toolWrench'), metaitem('robot.arm.ev'), metaitem('field.generator.hv')],
+		[ore('craftingToolWrench'), metaitem('robot.arm.ev'), metaitem('field.generator.hv')],
 		[ore('screwStainlessSteel'), ore('stickPolytetrafluoroethylene'), metaitem('robot.arm.ev')],
-		[ore('stickPolytetrafluoroethylene'), ore('screwStainlessSteel'), ore('toolScrewdriver')]
+		[ore('stickPolytetrafluoroethylene'), ore('screwStainlessSteel'), ore('craftingToolScrewdriver')]
 ])

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1369,3 +1369,11 @@ crafting.addShaped("gregtech:fluid_hatch.export.lv", metaitem('fluid_hatch.expor
 		[null, metaitem('hull.lv'), null],
 		[null, item('minecraft:glass'), null]
 ])
+
+// Multiblock Builder
+
+crafting.replaceShaped("gregtech:multiblock_builder", metaitem('tool.multiblock_builder'), [
+		[ore('toolWrench'), metaitem('robot.arm.ev'), metaitem('field.generator.hv')],
+		[ore('screwStainlessSteel'), ore('stickPolytetrafluoroethylene'), metaitem('robot.arm.ev')],
+		[ore('stickPolytetrafluoroethylene'), ore('screwStainlessSteel'), ore('toolScrewdriver')]
+])

--- a/groovy/postInit/mod/StorageDrawers.groovy
+++ b/groovy/postInit/mod/StorageDrawers.groovy
@@ -15,3 +15,8 @@ for (name in name_removals) {
 
 crafting.replaceShapeless("storagedrawers:key_quantify", item('storagedrawers:quantify_key'), [item('storagedrawers:drawer_key'), item('minecraft:book')])
 crafting.replaceShapeless("storagedrawers:key_concealment", item('storagedrawers:shroud_key'), [item('storagedrawers:drawer_key'), item('minecraft:name_tag')])
+crafting.replaceShaped("storagedrawers:key_drawer", item('storagedrawers:drawer_key'), [
+        [null, ore('stickBrass'), null],
+        [ore('toolFile'), ore('stickBrass'), null],
+        [null, ore('plateBrass'), null]
+])

--- a/groovy/postInit/mod/StorageDrawers.groovy
+++ b/groovy/postInit/mod/StorageDrawers.groovy
@@ -17,6 +17,6 @@ crafting.replaceShapeless("storagedrawers:key_quantify", item('storagedrawers:qu
 crafting.replaceShapeless("storagedrawers:key_concealment", item('storagedrawers:shroud_key'), [item('storagedrawers:drawer_key'), item('minecraft:name_tag')])
 crafting.replaceShaped("storagedrawers:key_drawer", item('storagedrawers:drawer_key'), [
         [null, ore('stickBrass'), null],
-        [ore('toolFile'), ore('stickBrass'), null],
+        [ore('craftingToolFile'), ore('stickBrass'), null],
         [null, ore('plateBrass'), null]
 ])


### PR DESCRIPTION
Makes drawer key use brass (this is so it can be made in LV/steam)

Replaces multiblock builder recipe so it is actually possible.(Gated to EV since to quote planet "only in EV do the setups become brobdingnagian in size")

![image](https://github.com/SymmetricDevs/Supersymmetry/assets/97848034/3d600c07-643b-4002-85c2-4a3c90a45251)
![image](https://github.com/SymmetricDevs/Supersymmetry/assets/97848034/5b01e910-cee0-45dd-b3e7-7b7eaadfa54c)
