### PR TITLE
Fixing Ore Deposit Rates

### DIFF
--- a/config/gregtech/worldgen/vein/beneath/chromite_vein
+++ b/config/gregtech/worldgen/vein/beneath/chromite_vein
@@ -1,0 +1,31 @@
+{
+  "weight": 50,
+  "density": 1,
+  "dimension_filter": ["dimension_id:10"],
+  "max_height": 255,
+  "min_height": 0,
+  "generator": {
+    "type": "layered",
+    "radius": [
+      12,
+      12
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:olivine"
+      },
+      {
+        "secondary": "ore:magnetite"
+      },
+      {
+        "between": "ore:chromite"
+      },
+      {
+        "sporadic": "ore:emerald"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/tantalum_vein.json
+++ b/config/gregtech/worldgen/vein/nether/tantalum_vein.json
@@ -1,0 +1,33 @@
+{
+  "weight": 30,
+  "density": 1,
+  "max_height": 80,
+  "min_height": 0,
+   "dimension_filter":[
+      "dimension_id:-1"
+   ],
+  "generator": {
+    "type": "layered",
+    "radius": [
+      8,
+      8
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:tantalite"
+      },
+      {
+        "secondary": "ore:columbite"
+      },
+      {
+        "between": "ore:banded_iron"
+      },
+      {
+        "sporadic": "ore:pyrochlore"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/tungsten_vein
+++ b/config/gregtech/worldgen/vein/nether/tungsten_vein
@@ -1,0 +1,33 @@
+{
+  "weight": 30,
+  "density": 1,
+  "max_height": 80,
+  "min_height": 0,
+   "dimension_filter":[
+      "dimension_id:-1"
+   ],
+  "generator": {
+    "type": "layered",
+    "radius": [
+      8,
+      8
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:scheelite"
+      },
+      {
+        "secondary": "ore:wolframite"
+      },
+      {
+        "between": "ore:bismuthinite"
+      },
+      {
+        "sporadic": "ore:sphalerite"
+      }
+    ]
+  }
+}

--- a/groovy/postInit/mod/ArchitectureCraft.groovy
+++ b/groovy/postInit/mod/ArchitectureCraft.groovy
@@ -22,6 +22,6 @@ crafting.replaceShaped('architecturecraft:item.architecturecraft.chisel3', item(
 
 crafting.replaceShaped('architecturecraft:item.architecturecraft.hammer4', item('architecturecraft:hammer'), [
         [null, null, null],
-        [metaitem('plateIron'), metaitem('plateIron'), metaitem('plateIron')],
-        [ore('craftingToolFile'), item('minecraft:stick'), ore('craftingToolHammer')]
+        [ore('plateIron'), ore('plateIron'), ore('plateIron')],
+        [ore('craftingToolFile'), item('minecraft:stick'), ore('craftingToolHardHammer')]
 ])

--- a/structures/active/Alluvial.rcbp
+++ b/structures/active/Alluvial.rcbp
@@ -12,6 +12,10 @@
     {
       "biomes": "$RIVER",
       "weight": 2.5
+    },
+    {
+      "biomes": "",
+      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Hydrothermal.rcbp
+++ b/structures/active/Hydrothermal.rcbp
@@ -15,6 +15,10 @@
     {
       "biomes": "$JUNGLE",
       "weight": 0.1
+    },
+    {
+      "biomes": "",
+      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/MagmaticHydrothermal.rcbp
+++ b/structures/active/MagmaticHydrothermal.rcbp
@@ -2,11 +2,11 @@
   "data": [
     {
       "biomes": "$MOUNTAIN",
-      "weight": 0.75
+      "weight": 1.5
     },
     {
       "biomes": "$JUNGLE",
-      "weight": 0.25
+      "weight": 0.50
     },
     {
       "biomes": "$HILLS",
@@ -15,6 +15,10 @@
     {
       "biomes": "$LUSH",
       "weight": 0.4
+    },
+    {
+      "biomes": "",
+      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Metamorphic.rcbp
+++ b/structures/active/Metamorphic.rcbp
@@ -2,11 +2,11 @@
   "data": [
     {
       "biomes": "$FOREST",
-      "weight": 0.5
+      "weight": 0.75
     },
     {
       "biomes": "$HILLS",
-      "weight": 0.4
+      "weight": 0.5
     },
     {
       "biomes": "",

--- a/structures/active/Orthomagmatic.rcbp
+++ b/structures/active/Orthomagmatic.rcbp
@@ -2,15 +2,19 @@
   "data": [
     {
       "biomes": "$WASTELAND",
-      "weight": 1.2
+      "weight": 1.5
     },
     {
       "biomes": "$MOUNTAIN",
-      "weight": 0.6
+      "weight": 0.75
     },
     {
       "biomes": "volcanic",
-      "weight": 1.2
+      "weight": 2
+    },
+    {
+      "biomes": "",
+      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Sedimentary.rcbp
+++ b/structures/active/Sedimentary.rcbp
@@ -10,15 +10,15 @@
     },
     {
       "biomes": "$SANDY",
-      "weight": 0.65
+      "weight": 0.75
     },
     {
       "biomes": "$SAVANNA",
-      "weight": 0.65
+      "weight": 0.75
     },
     {
       "biomes": "$MESA",
-      "weight": 0.9
+      "weight": 0.75
     },
     {
       "biomes": "",


### PR DESCRIPTION
-Gave every deposit a base spawn rate of 0.5
-Increased the spawn rate of deposits in rare biomes such as mountains, wastelands, and volcanic
-Decreased the spawn rate of deposits in large common biomes such as mesas and deserts