### PR TITLE
Set Default World Generator as a client only mod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -891,6 +891,7 @@
       "required": true
     },
     {
+      "clientOnly": true,
       "projectID": 241140,
       "fileID": 2499252,
       "required": true


### PR DESCRIPTION
## What
Set Default World Generator as a client only mod as per planets request

## Implementation Details
Option changed

## Outcome
DWG is a client side mod now