### PR TITLE
Fixed quest and some techgun oredicts

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -1707,7 +1707,7 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
-              "Count:3": 29,
+              "Count:3": 25,
               "Damage:2": 8,
               "OreDict:8": "",
               "id:8": "gregtech:metal_casing"
@@ -2005,7 +2005,7 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
-              "Count:3": 33,
+              "Count:3": 32,
               "Damage:2": 1,
               "OreDict:8": "",
               "id:8": "gregtech:metal_casing"
@@ -8909,7 +8909,7 @@
           "partialMatch:1": 1,
           "requiredItems:9": {
             "0:10": {
-              "Count:3": 16,
+              "Count:3": 15,
               "Damage:2": 0,
               "OreDict:8": "",
               "id:8": "gregtechfoodoption:gtfo_casing"
@@ -12039,7 +12039,7 @@
           "autoConsume:1": 0,
           "consume:1": 0,
           "groupDetect:1": 0,
-          "ignoreNBT:1": 0,
+          "ignoreNBT:1": 1,
           "index:3": 0,
           "partialMatch:1": 1,
           "requiredItems:9": {

--- a/groovy/postInit/mod/TechGuns.groovy
+++ b/groovy/postInit/mod/TechGuns.groovy
@@ -1346,3 +1346,20 @@ GunStatTweaker.setWeaponStat("scar","DAMAGE_MIN", 12);
 //Minigun (20 shots per second)
 GunStatTweaker.setWeaponStat("minigun","DAMAGE", 5);
 GunStatTweaker.setWeaponStat("minigun","DAMAGE_MIN", 4);
+
+//-------------------Removing TechGuns plates from jei so that they don't flash when crafting----------------
+
+//Iron Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 46))
+//Copper Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 47))
+//Tin Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 48))
+//Bronze Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 49))
+//Steel Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 50))
+//Lead Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 52))
+//Titanium Plate
+mods.jei.removeAndHide(item('techguns:itemshared', 54))


### PR DESCRIPTION
##What
Fixed quest for Coke Oven, PBF and Primitive Baking Oven

From that issue: https://github.com/SymmetricDevs/Supersymmetry/issues/648

Also remove from jei flashing techguns plates, which are suitable for gt plates according to the oredict


## Implementation Details
perhaps someone who knows the groovy script better can put a change in tech guns in the method

## Outcome
"Fixes":
https://github.com/SymmetricDevs/Supersymmetry/issues/648

## Potential Compatibility Issues
No Compatibility issues

