### PR TITLE
Obamium ore veins

### DIFF
--- a/config/gregtech/worldgen/vein/beneath/chromite_vein.json
+++ b/config/gregtech/worldgen/vein/beneath/chromite_vein.json
@@ -1,0 +1,31 @@
+{
+  "weight": 80,
+  "density": 0.5,
+  "dimension_filter": ["dimension_id:10"],
+  "max_height": 255,
+  "min_height": 0,
+  "generator": {
+    "type": "layered",
+    "radius": [
+      25,
+      25
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:olivine"
+      },
+      {
+        "secondary": "ore:magnetite"
+      },
+      {
+        "between": "ore:chromite"
+      },
+      {
+        "sporadic": "ore:emerald"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/tantalite_vein.json
+++ b/config/gregtech/worldgen/vein/nether/tantalite_vein.json
@@ -1,5 +1,5 @@
 {
-  "weight": 120,
+  "weight": 30,
   "density": 0.75,
    "max_height":120,
    "min_height":0,
@@ -9,8 +9,8 @@
   "generator": {
     "type": "layered",
     "radius": [
-      25,
-      25
+      8,
+      8
     ]
   },
   "filler": {

--- a/config/gregtech/worldgen/vein/nether/tantalite_vein.json
+++ b/config/gregtech/worldgen/vein/nether/tantalite_vein.json
@@ -1,0 +1,33 @@
+{
+  "weight": 120,
+  "density": 0.75,
+   "max_height":120,
+   "min_height":0,
+   "dimension_filter":[
+      "dimension_id:-1"
+   ],
+  "generator": {
+    "type": "layered",
+    "radius": [
+      25,
+      25
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:tantalite"
+      },
+      {
+        "secondary": "ore:columbite"
+      },
+      {
+        "between": "ore:pyrochlore"
+      },
+      {
+        "sporadic": "ore:banded_iron"
+      }
+    ]
+  }
+}

--- a/config/gregtech/worldgen/vein/nether/wolframite_vein.json
+++ b/config/gregtech/worldgen/vein/nether/wolframite_vein.json
@@ -23,10 +23,10 @@
         "secondary": "ore:scheelite"
       },
       {
-        "between": "ore:bismuthinite"
+        "between": "ore:sphalerite"
       },
       {
-        "sporadic": "ore:sphalerite"
+        "sporadic": "ore:bismuthinite"
       }
     ]
   }

--- a/config/gregtech/worldgen/vein/nether/wolframite_vein.json
+++ b/config/gregtech/worldgen/vein/nether/wolframite_vein.json
@@ -1,0 +1,33 @@
+{
+  "weight": 30,
+  "density": 0.75,
+   "max_height":120,
+   "min_height":0,
+   "dimension_filter":[
+      "dimension_id:-1"
+   ],
+  "generator": {
+    "type": "layered",
+    "radius": [
+      8,
+      8
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:wolframite"
+      },
+      {
+        "secondary": "ore:scheelite"
+      },
+      {
+        "between": "ore:bismuthinite"
+      },
+      {
+        "sporadic": "ore:sphalerite"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Created a Tantalite Vein
   -Weight of 30
   -Size of 8x8
   -Located in the Nether
   -Composed of Tantalite, Columbite, Pyrochlore, and sporadic Banded Iron
Created a Wolframite Vein
   -Weight of 30
   -Size of 8x8
   -Located in the Nether
   -Composed of Wolframite, Scheelite, Bismuthinite, and sporadic Sphalerite
Created a Chromite Vein
   -Weight of 40
   -Size of 12x12
   -Located in the Beneath
   -Composed of Olivine, Chromite, Magnetite, and sporadic Emerald