### PR TITLE
Update Better Building Wands to version 0.13.1 to remove aluminum pipelike exploit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -702,7 +702,7 @@
     },
     {
       "projectID": 238403,
-      "fileID": 2443194,
+      "fileID": 2685833,
       "required": true
     },
     {

--- a/modValidationFile.dat
+++ b/modValidationFile.dat
@@ -17,7 +17,7 @@ A_Little_Extra_Tiles-1.0.23.jar
 BarrelsDrumsStorageAndMore-0.0.24.jar
 base-1.12.2-3.14.0.jar
 BetterAdvancements-1.12.2-0.1.0.77.jar
-BetterBuildersWands-1.12-0.11.1.245+69d0d70.jar
+BetterBuildersWands-1.12.2-0.13.1.269+13450ff-dev.jar
 BetterFps-1.4.8.jar
 BetterMineshaftsForge-1.12.2-2.2.1.jar
 BetterPlacement-1.0.0-1.jar


### PR DESCRIPTION
Exorcised the haunted wand mod, it is safe now 
Note, never update to version 0.13.2 as the exploit returns
