### PR TITLE
JEI Cleanup

### DIFF
--- a/groovy/postInit/biology/GreenhouseChain.groovy
+++ b/groovy/postInit/biology/GreenhouseChain.groovy
@@ -4,7 +4,6 @@ import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
-
 MIXER = recipemap('mixer')
 FLUID_HEATER = recipemap('fluid_heater')
 CENTRIFUGE = recipemap('centrifuge')
@@ -73,76 +72,46 @@ CHEMICAL_BATH.recipeBuilder()
 
 //FERTILIZER CHAIN
 
-def nitrogenNutrients = [
-        metaitem('dustAmmoniumChloride'),
-        metaitem('dustAmmoniumNitrate'),
-        metaitem('dustAmmoniumSulfate'),
-        metaitem('dustUrea')
-];
+MIXER.recipeBuilder()
+        .inputs(ore('nutrientNitrogen'))
+        .inputs(ore('nutrientPotassium'))
+        .inputs(ore('nutrientPhosphorous'))
+        .outputs(metaitem('fertilizer') * 5)
+        .EUt(30)
+        .duration(100)
+        .buildAndRegister();
 
-def potassiumNutrients = [
-        metaitem('dustAsh'),
-        metaitem('dustCharcoal'),
-        metaitem('dustRockSalt'),
-        metaitem('dustPotassiumCarbonate'),
-        metaitem('dustPotash')
-];
+MIXER.recipeBuilder()
+        .inputs(ore('dustAmmoniumDihydrogenPhosphate') * 2)
+        .inputs(ore('nutrientPotassium'))
+        .outputs(metaitem('fertilizer') * 5)
+        .EUt(30)
+        .duration(100)
+        .buildAndRegister()
 
-def phosphorusNutrients = [
-        metaitem('dustChlorapatite'),
-        metaitem('dustHydroxyapatite'),
-        metaitem('dustFluorapatite'),
-        metaitem('dustTricalciumPhosphate'),
-        metaitem('dustPhosphorus'),
-        metaitem('dustPhosphorite'),
-        item('minecraft:dye', 15)
-];
+MIXER.recipeBuilder()
+        .inputs(ore('dustSaltpeter') * 2)
+        .inputs(ore('nutrientPhosphorous'))
+        .outputs(metaitem('fertilizer') * 5)
+        .EUt(30)
+        .duration(100)
+        .buildAndRegister()
 
-for (p in phosphorusNutrients) {
-    for (n in nitrogenNutrients) {
-        for (k in potassiumNutrients) {
-            MIXER.recipeBuilder()
-                    .inputs(p)
-                    .inputs(n)
-                    .inputs(k)
-                    .outputs(metaitem('fertilizer') * 5)
-                    .EUt(30)
-                    .duration(100)
-                    .buildAndRegister()
-        }
-    }
-    MIXER.recipeBuilder()
-            .inputs(ore('dustAmmoniumDihydrogenPhosphate') * 2)
-            .inputs(p)
-            .outputs(metaitem('fertilizer') * 5)
-            .EUt(30)
-            .duration(100)
-            .buildAndRegister()
+MIXER.recipeBuilder()
+        .inputs(metaitem('bio_chaff') * 2)
+        .inputs(ore('nutrientPhosphorous'))
+        .outputs(metaitem('fertilizer') * 5)
+        .EUt(30)
+        .duration(100)
+        .buildAndRegister()
 
-    MIXER.recipeBuilder()
-            .inputs(ore('dustSaltpeter') * 2)
-            .inputs(p)
-            .outputs(metaitem('fertilizer') * 5)
-            .EUt(30)
-            .duration(100)
-            .buildAndRegister()
-
-    MIXER.recipeBuilder()
-            .inputs(metaitem('bio_chaff') * 2)
-            .inputs(p)
-            .outputs(metaitem('fertilizer') * 5)
-            .EUt(30)
-            .duration(100)
-            .buildAndRegister()
-
-    MIXER.recipeBuilder()
-            .fluidInputs(fluid('fermented_biomass') * 1000)
-            .inputs(p)
-            .outputs(metaitem('fertilizer') * 5)
-            .EUt(30)
-            .duration(100)
-            .buildAndRegister()
-}
+MIXER.recipeBuilder()
+        .fluidInputs(fluid('fermented_biomass') * 1000)
+        .inputs(ore('nutrientPhosphorous'))
+        .outputs(metaitem('fertilizer') * 5)
+        .EUt(30)
+        .duration(100)
+        .buildAndRegister()
 
 MIXER.recipeBuilder()
         .inputs(metaitem('fertilizer') * 2)
@@ -151,6 +120,8 @@ MIXER.recipeBuilder()
         .EUt(30)
         .duration(60)
         .buildAndRegister()
+
+
 
 COMPRESSOR.recipeBuilder()
         .inputs(ore('treeLeaves') * 16)

--- a/groovy/postInit/electronics/ElectronicCircuits.groovy
+++ b/groovy/postInit/electronics/ElectronicCircuits.groovy
@@ -1,3 +1,5 @@
+import gregtech.api.recipes.ingredients.GTRecipeItemInput;
+
 // Diode * 2
 mods.gregtech.assembler.removeByInput(30, [metaitem('wireFineAnnealedCopper') * 4, metaitem('dustSmallGalliumArsenide')], [fluid('glass') * 144])
 // Diode * 1
@@ -10,38 +12,60 @@ mods.gregtech.assembler.removeByInput(30, [metaitem('wireFineCopper') * 4, metai
 mods.gregtech.assembler.removeByInput(30, [metaitem('wireFineAnnealedCopper') * 4, metaitem('dustSmallGalliumArsenide')], [fluid('plastic') * 144])
 // Diode * 2
 mods.gregtech.assembler.removeByInput(30, [metaitem('wireFineCopper') * 4, metaitem('dustSmallGalliumArsenide')], [fluid('plastic') * 144])
+// Resistor * 2
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCoal'), metaitem('wireFineCopper') * 4], [fluid('glue') * 100])
+// Resistor * 2
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCharcoal'), metaitem('wireFineCopper') * 4], [fluid('glue') * 100])
+// Resistor * 2
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCarbon'), metaitem('wireFineCopper') * 4], [fluid('glue') * 100])
+// Resistor * 4
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCoal'), metaitem('wireFineAnnealedCopper') * 4], [fluid('glue') * 100])
+// Resistor * 4
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCharcoal'), metaitem('wireFineAnnealedCopper') * 4], [fluid('glue') * 100])
+// Resistor * 4
+mods.gregtech.assembler.removeByInput(6, [metaitem('dustCarbon'), metaitem('wireFineAnnealedCopper') * 4], [fluid('glue') * 100])
 
-//Remove steel plates from electronic circuits since they were unnecessary
+crafting.removeByOutput(metaitem('component.resistor')) 
 
-crafting.replaceShaped("gregtech:electronic_circuit_lv", metaitem('circuit.electronic'), [
-        [metaitem('component.resistor'), ore('craftingToolWireCutter'), metaitem('component.resistor')],
-        [metaitem('circuit.vacuum_tube'), metaitem('circuit_board.basic'), metaitem('circuit.vacuum_tube')],
-        [ore('cableGtSingleRedAlloy'), ore('cableGtSingleRedAlloy'), ore('cableGtSingleRedAlloy')]])
+carbons = new ItemStack[]{
+        metaitem('dustCoal'),
+        metaitem('dustCharcoal'),
+        metaitem('dustCarbon'),
+        metaitem('dustCoal'),
+        metaitem('dustHighPurityCarbon'),
+        metaitem('dustAnthracite'),
+        metaitem('dustCoal')
+}
 
-crafting.replaceShaped("gregtech:electronic_circuit_mv", metaitem('circuit.good_electronic'), [
-        [metaitem('component.diode'), ore('craftingToolWireCutter'), metaitem('component.diode')],
-        [metaitem('circuit.electronic'), metaitem('circuit_board.good'), metaitem('circuit.electronic')],
-        [ore('wireGtSingleCopper'), metaitem('circuit.electronic'), ore('wireGtSingleCopper')]])
+mods.gregtech.assembler.recipeBuilder()
+        .fluidInputs(fluid('glue') * 100)
+        .input(new GTRecipeItemInput(carbons, 1))
+        .inputs(ore('wireFineCopper') * 4)
+        .outputs(metaitem('component.resistor') * 2)
+        .duration(160)
+        .EUt(6)
+        .buildAndRegister();
 
-crafting.addShaped('resistor_wire_anthracite', metaitem('component.resistor') * 2, [
-    [metaitem('rubber_drop'),item('minecraft:paper'),metaitem('rubber_drop')],
-    [ore('wireGtSingleCopper'),ore('dustAnthracite'), ore('wireGtSingleCopper')],
-    [null,item('minecraft:paper'),null]])
+mods.gregtech.assembler.recipeBuilder()
+        .fluidInputs(fluid('glue') * 100)
+        .input(new GTRecipeItemInput(carbons, 1))
+        .inputs(ore('wireFineAnnealedCopper') * 4)
+        .outputs(metaitem('component.resistor') * 4)
+        .duration(160)
+        .EUt(6)
+        .buildAndRegister();        
 
-crafting.addShaped('resistor_wire_fine_anthracite', metaitem('component.resistor') * 2, [
-    [metaitem('rubber_drop'),item('minecraft:paper'),metaitem('rubber_drop')],
-    [ore('wireFineCopper'),ore('dustAnthracite'), ore('wireFineCopper')],
-    [null,item('minecraft:paper'),null]])
-	
-crafting.addShaped('resistor_wire_coke', metaitem('component.resistor') * 2, [
-    [metaitem('rubber_drop'),item('minecraft:paper'),metaitem('rubber_drop')],
-    [ore('wireGtSingleCopper'),ore('dustCoke'), ore('wireGtSingleCopper')],
-    [null,item('minecraft:paper'),null]])
-
-crafting.addShaped('resistor_wire_fine_coke', metaitem('component.resistor') * 2, [
-    [metaitem('rubber_drop'),item('minecraft:paper'),metaitem('rubber_drop')],
-    [ore('wireFineCopper'),ore('dustCoke'), ore('wireFineCopper')],
-    [null,item('minecraft:paper'),null]])
+crafting.shapedBuilder()               
+        .name('resistor_wire')            
+        .output(metaitem('component.resistor') * 2)      
+        .matrix('RPR',                      
+                'WCW',                 
+                ' P ')
+        .key('R', metaitem('rubber_drop'))  
+        .key('P', item('minecraft:paper'))         
+        .key('W', ore('wireGtSingleCopper') | ore('wireFineCopper'))  
+        .key('C', ore('dustAnthracite') | ore('dustCoke') | ore('dustCarbon') | ore('dustCoal') | ore('dustCharcoal'))             
+        .register() 
 
 mods.gregtech.assembler.recipeBuilder()
         .fluidInputs(fluid('glass') * 144)
@@ -113,40 +137,4 @@ mods.gregtech.assembler.recipeBuilder()
         .outputs(metaitem('component.diode') * 16)
         .duration(400)
         .EUt(30)
-        .buildAndRegister();
-
-mods.gregtech.assembler.recipeBuilder()
-        .fluidInputs(fluid('glue') * 100)
-        .inputs(ore('dustAnthracite') * 1)
-        .inputs(ore('wireFineCopper') * 4)
-        .outputs(metaitem('component.resistor') * 2)
-        .duration(160)
-        .EUt(6)
-        .buildAndRegister();
-
-mods.gregtech.assembler.recipeBuilder()
-        .fluidInputs(fluid('glue') * 100)
-        .inputs(ore('dustAnthracite') * 1)
-        .inputs(ore('wireFineAnnealedCopper') * 4)
-        .outputs(metaitem('component.resistor') * 4)
-        .duration(160)
-        .EUt(6)
-        .buildAndRegister();
-
-mods.gregtech.assembler.recipeBuilder()
-        .fluidInputs(fluid('glue') * 100)
-        .inputs(ore('dustCoke') * 1)
-        .inputs(ore('wireFineCopper') * 4)
-        .outputs(metaitem('component.resistor') * 2)
-        .duration(160)
-        .EUt(6)
-        .buildAndRegister();
-
-mods.gregtech.assembler.recipeBuilder()
-        .fluidInputs(fluid('glue') * 100)
-        .inputs(ore('dustCoke') * 1)
-        .inputs(ore('wireFineAnnealedCopper') * 4)
-        .outputs(metaitem('component.resistor') * 4)
-        .duration(160)
-        .EUt(6)
         .buildAndRegister();

--- a/groovy/postInit/electronics/ElectronicCircuits.groovy
+++ b/groovy/postInit/electronics/ElectronicCircuits.groovy
@@ -31,10 +31,9 @@ carbons = new ItemStack[]{
         metaitem('dustCoal'),
         metaitem('dustCharcoal'),
         metaitem('dustCarbon'),
-        metaitem('dustCoal'),
         metaitem('dustHighPurityCarbon'),
         metaitem('dustAnthracite'),
-        metaitem('dustCoal')
+        metaitem('dustCoke')
 }
 
 mods.gregtech.assembler.recipeBuilder()

--- a/groovy/prePostInit/oreDict.groovy
+++ b/groovy/prePostInit/oreDict.groovy
@@ -346,3 +346,25 @@ for (knife in name_knifeNTP) {
     ore('knifeNTP').add(item(knife))
 }
 */
+
+// Nitrogen Nutrients
+ore('nutrientNitrogen').add(metaitem('dustAmmoniumChloride'))
+ore('nutrientNitrogen').add(metaitem('dustAmmoniumNitrate'))
+ore('nutrientNitrogen').add(metaitem('dustAmmoniumSulfate'))
+ore('nutrientNitrogen').add(metaitem('dustUrea'))
+
+// Potassium Nutrients
+ore('nutrientPotassium').add(metaitem('dustAsh'))
+ore('nutrientPotassium').add(metaitem('dustCharcoal'))
+ore('nutrientPotassium').add(metaitem('dustRockSalt'))
+ore('nutrientPotassium').add(metaitem('dustPotassiumCarbonate'))
+ore('nutrientPotassium').add(metaitem('dustPotash'))
+
+// Phosphorous Nutrients
+ore('nutrientPhosphorous').add(metaitem('dustChlorapatite'))
+ore('nutrientPhosphorous').add(metaitem('dustHydroxyapatite'))
+ore('nutrientPhosphorous').add(metaitem('dustFluorapatite'))
+ore('nutrientPhosphorous').add(metaitem('dustTricalciumPhosphate'))
+ore('nutrientPhosphorous').add(metaitem('dustPhosphorus'))
+ore('nutrientPhosphorous').add(metaitem('dustPhosphorite'))
+ore('nutrientPhosphorous').add(item('minecraft:dye', 15))


### PR DESCRIPTION
## What
This unclutters some recipes.

## Implementation Details
The fertilizer constituents have been moved into oredicts. For the resistors, a GTRecipeInput is passed directly to the recipe builder instead of individual item stacks.

## Outcome
Around 160 pages worth of fertilizer recipes as well as 20 pages worth of resistor recipes have been compacted down.
