### PR TITLE
move working fluid steam turbine recipes to large turbine exclusively

### DIFF
--- a/groovy/prePostInit/Thermodynamics.groovy
+++ b/groovy/prePostInit/Thermodynamics.groovy
@@ -774,23 +774,30 @@ for (WorkingFluid in WorkingFluids) {
             .buildAndRegister();
 
     recipemap('steam_turbine').recipeBuilder()
+            .fluidInputs(liquid(WorkingFluid.heated_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
+            .fluidOutputs(liquid(WorkingFluid.leftover_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
+            .duration(WorkingFluid.duration * WorkingFluid.efficiency)
+            .EUt(32)
+            .buildAndRegister()
+
+    recipemap('large_steam_turbine').recipeBuilder()
             .circuitMeta(1)
             .fluidInputs(liquid(WorkingFluid.heated_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
             .fluidOutputs(liquid(WorkingFluid.leftover_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
             .duration(WorkingFluid.duration * WorkingFluid.efficiency)
             .EUt(32)
-            .buildAndRegister();
+            .buildAndRegister()
 
     for (lubricant in Globals.lubricants) {
-            recipemap('steam_turbine').recipeBuilder()
+            recipemap('large_steam_turbine').recipeBuilder()
                     .fluidInputs(liquid(lubricant.name) * lubricant.amount_required)
                     .fluidInputs(liquid(WorkingFluid.heated_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
                     .fluidOutputs(liquid(WorkingFluid.leftover_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor))
                     .duration((int) (WorkingFluid.duration * WorkingFluid.efficiency * lubricant.boost))
                     .EUt(32)
-                    .buildAndRegister();
+                    .buildAndRegister()
     }
-        
+
     recipemap('cooling_tower').recipeBuilder()
             .fluidInputs(liquid(WorkingFluid.leftover_fluid) * (WorkingFluid.amount_to_use * WorkingFluid.conversion_factor * 64))
             .fluidInputs(liquid('water') * 1000)


### PR DESCRIPTION
## What
Moves the working fluid steam turbines to the large steam turbine recipemap exclusively. Keeps only regular steam -> exhaust steam in the singleblock turbine.

## Implementation Details
Requires SymmetricDevs/Susy-Core#183.

## Outcome
Prevents requiring configuration circuits in every singleblock steam turbine.

## Potential Compatibility Issues
May break existing setups using lubricant in singleblock turbines.
