### PR TITLE
Add localisation fixing file

### DIFF
--- a/build/questbookLocalisationShift.py
+++ b/build/questbookLocalisationShift.py
@@ -28,7 +28,9 @@ def ShiftLocalisationKeys(questbook: dict, location: str):
 		actualQuestTitel = questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"]
 		actualQuestDescription = questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"]
 
-		if actualQuestTitel != wantedQuestTitel or actualQuestDescription != wantedQuestDescription:
+		isLocalisedCheck = "susy.quest.db"
+
+		if (actualQuestTitel[0:13] == isLocalisedCheck or actualQuestDescription[0:13] == isLocalisedCheck) and (actualQuestTitel != wantedQuestTitel or actualQuestDescription != wantedQuestDescription):
 			questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"] = wantedQuestTitel
 			questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"] = wantedQuestDescription
 			print(f"Quest {questId} - Fixed!")

--- a/build/questbookLocalisationShift.py
+++ b/build/questbookLocalisationShift.py
@@ -28,7 +28,7 @@ def ShiftLocalisationKeys(questbook: dict, location: str):
 		actualQuestTitel = questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"]
 		actualQuestDescription = questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"]
 
-		if actualQuestTitel != wantedQuestTitel and actualQuestDescription != wantedQuestDescription:
+		if actualQuestTitel != wantedQuestTitel or actualQuestDescription != wantedQuestDescription:
 			questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"] = wantedQuestTitel
 			questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"] = wantedQuestDescription
 			print(f"Quest {questId} - Fixed!")

--- a/build/questbookLocalisationShift.py
+++ b/build/questbookLocalisationShift.py
@@ -1,0 +1,46 @@
+# Created by The Science Demon for trainvoi
+# Next time, don't have such a skill issue, thanks
+
+import json
+import os
+
+questbookPath = os.path.normpath(os.path.abspath(f"{__file__}/../../config/betterquesting/DefaultQuests.json"))
+
+def Setup():
+	questbook = GetQuestbook()
+
+	ShiftLocalisationKeys(questbook = questbook, location = "questDatabase:9")
+
+	input("Press Enter to exit...")
+
+def GetQuestbook():
+	with open(questbookPath, "r") as file:
+		return json.load(file)
+
+def ShiftLocalisationKeys(questbook: dict, location: str):
+	for quest in dict(questbook[location]):
+		questId = questbook[location][quest]["questID:3"]
+		print(f"Found quest with ID: {questId}")
+
+		wantedQuestTitel = "susy.quest.db.%s.%s" % (questId, "title")
+		wantedQuestDescription = "susy.quest.db.%s.%s" % (questId, "desc")
+
+		actualQuestTitel = questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"]
+		actualQuestDescription = questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"]
+
+		if actualQuestTitel != wantedQuestTitel and actualQuestDescription != wantedQuestDescription:
+			questbook[location][quest]["properties:10"]["betterquesting:10"]["name:8"] = wantedQuestTitel
+			questbook[location][quest]["properties:10"]["betterquesting:10"]["desc:8"] = wantedQuestDescription
+			print(f"Quest {questId} - Fixed!")
+		else:
+			print(f"Quest {questId} - Fine as is")
+
+		print("--------")
+	
+	with open(questbookPath, "w") as file:
+		json.dump(questbook, file, indent = 2)
+
+	print("Done!")
+
+if (__name__ == "__main__"):
+	Setup()


### PR DESCRIPTION
## What
This file (which was requested by trainvoi) sets, upon execution, all quests' name and desc localisation keys to the quest's ID.

ex:
Quest No. **123** - name / desc: "susy.quest.db.**135**.title/desc"
Upon exection:
Quest No. **123** - name / desc: "susy.quest.db.**123**.title/desc"

Useful when having deleted a quest. (As was the case with trainvoi)

## Outcome
Added a file (`questbookLocalisationShift.py`) under `Supersymmetry\build`.
