### PR TITLE
Add chest sorting to Industrial Renewal storage racks

### DIFF
--- a/config/InvTweaksCompatibility.xml
+++ b/config/InvTweaksCompatibility.xml
@@ -1,4 +1,3 @@
 <root>
-    <chest class="cassiokf.industrialrenewal.gui.container.ContainerStorageChest"/>
-    <chest class="gregtech.api.gui.impl.ModularUIContainer"/>
+    <chest class="cassiokf.industrialrenewal.gui.container.ContainerStorageChest" disable_buttons="true"/>
 </root>

--- a/config/InvTweaksCompatibility.xml
+++ b/config/InvTweaksCompatibility.xml
@@ -1,0 +1,4 @@
+<root>
+    <chest class="cassiokf.industrialrenewal.gui.container.ContainerStorageChest"/>
+    <chest class="gregtech.api.gui.impl.ModularUIContainer"/>
+</root>


### PR DESCRIPTION
Simple change that allows middleclick sorting on crates and Industrial Renewal storage racks. I tested both and they work. Buttons were not added because they didn't fit well with the UI of either (the crate UI is too big and the Industrial Renewal search & scrollbars overlap with the Invtweaks UI).