### PR TITLE
Add Discord rich presence mod (Simple-RPC)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -361,6 +361,11 @@
       "required": true
     },
     {
+      "projectID": 411816,
+      "fileID": 3899272,
+      "required": true
+    },
+    {
       "projectID": 284973,
       "fileID": 3758733,
       "required": true

--- a/simple-rpc/server-entries.toml
+++ b/simple-rpc/server-entries.toml
@@ -1,0 +1,7 @@
+#Enable/Disable Server Entries overrides
+enabled = false
+#Internal Version Number. NO TOUCHY!
+version = 1
+#Server override entries
+entry = []
+

--- a/simple-rpc/simple-rpc.toml
+++ b/simple-rpc/simple-rpc.toml
@@ -1,0 +1,244 @@
+
+#General Config Section. See https://readme.firstdarkdev.xyz/simple-rpc/introduction/
+[general]
+	#The Application ID of the Discord App to use
+	applicationID = 1204111633148940299
+	#Enable/Disable the mod
+	enabled = true
+	#Enable/Disable debugging mode. WARNING: MAY CAUSE LOG SPAM!
+	debugging = false
+	#Enable/Disable the in game config screen. ONLY AVAILABLE WHEN CLOTH CONFIG IS INSTALLED!
+	configScreen = false
+	#Display the Icon and Pack Name in place of LargeImage from compatible launchers. DOES NOT WORK WITH CUSTOM APPS! ONLY THE DEFAULT ONE!
+	launcherIntegration = false
+	#Internal Version Number. NO TOUCHY!
+	version = 16
+
+#The Game Loading event
+[init]
+	#Enable/Disable the Game Loading Event
+	enabled = true
+	#The first line of text under the app name
+	description = "Game is starting..."
+	#The second line of text under the app name
+	state = ""
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "Gregification of the World!"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = ""
+	#The text that gets displayed when the small image is hovered
+	smallImageText = ""
+	#The buttons to display on Discord
+	buttons = []
+
+#The Main Menu event
+[main_menu]
+	#Enable/Disable the Main Menu Event
+	enabled = true
+	#The first line of text under the app name
+	description = "In Main Menu"
+	#The seconds line of text under the app name
+	state = ""
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "Gregification of the World!"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = ""
+	#The text that gets displayed when the small image is hovered
+	smallImageText = ""
+	#The buttons to display on Discord
+	buttons = []
+
+#The Server List event
+[server_list]
+	#Enable/Disable the Server List Event
+	enabled = false
+	#The first line of text under the app name
+	description = "%player% is looking for a server"
+	#The second line of text under the app name
+	state = "Searching for friends"
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "It's Minecraft %mcver%, but modded"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = "mclogo"
+	#The text that gets displayed when the small image is hovered
+	smallImageText = "%mods% mods installed"
+	#The buttons to display on Discord
+	buttons = []
+
+#The Realms Screen event
+[realms_list]
+	#Enable/Disable the Realms Screen Event
+	enabled = false
+	#The first line of text under the app name
+	description = "%player% is looking for a Realm"
+	#The second line of text under the app name
+	state = "Browsing Realms"
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "It's Minecraft %mcver%, but modded"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = "mclogo"
+	#The text that gets displayed when the small image is hovered
+	smallImageText = "%mods% mods installed"
+	#The buttons to display on Discord
+	buttons = []
+
+#The Join Game Event
+[join_game]
+	#Enable/Disable the Join Game Event
+	enabled = false
+	#The first line of text under the app name
+	description = "%player% is joining a game"
+	#The second line of text under the app name
+	state = "Joining Game"
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "It's Minecraft %mcver%, but modded"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = "mclogo"
+	#The text that gets displayed when the small image is hovered
+	smallImageText = "%mods% mods installed"
+	#The buttons to display on Discord
+	buttons = []
+
+#The Single Player Event
+[single_player]
+	#Enable/Disable the Single Player Event
+	enabled = true
+	#The first line of text under the app name
+	description = "Playing Singleplayer"
+	#The second line of text under the app name
+	state = ""
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "Gregification of the World!"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = ""
+	#The text that gets displayed when the small image is hovered
+	smallImageText = ""
+	#The buttons to display on Discord
+	buttons = []
+
+#The Multi Player Event
+[multi_player]
+	#Enable/Disable the Multi Player Event
+	enabled = true
+	#The first line of text under the app name
+	description = "Playing Multiplayer"
+	#The second line of text under the app name
+	state = ""
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "Gregification of the World!"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = ""
+	#The text that gets displayed when the small image is hovered
+	smallImageText = ""
+	#The buttons to display on Discord
+	buttons = []
+
+#The Realms Game Event
+[realms]
+	#Enable/Disable the Realms Game Event
+	enabled = false
+	#The first line of text under the app name
+	description = "Playing on %realmname%"
+	#The second line of text under the app name
+	state = "Playing on a Realm"
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "It's Minecraft %mcver%, but modded"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = "mclogo"
+	#The text that gets displayed when the small image is hovered
+	smallImageText = "%realmdescription%"
+	#The buttons to display on Discord
+	buttons = []
+
+#Fallback event for disabled events
+[generic]
+	#The first line of text under the app name
+	description = ""
+	#The second line of text under the app name
+	state = ""
+	#The Asset ID of the image to display as the large image
+	largeImageKey = "susy_logo"
+	#The text that gets displayed when the large image is hovered
+	largeImageText = "Gregification of the World!"
+	#The Asset ID of the image to display as the small image
+	smallImageKey = ""
+	#The text that gets displayed when the small image is hovered
+	smallImageText = ""
+	#The buttons to display on Discord
+	buttons = []
+
+#Dimension Information Overrides
+[dimension_overrides]
+	#Allows you to override the displayed values for dimensions
+	enabled = false
+
+	#The Dimensions to override
+	[[dimension_overrides.dimensions]]
+		#The name of the Dimension/Biome to override. FORMAT: modid:dimension or modid:biome
+		name = "overworld"
+		#The first line of text under the app name
+		description = "%player% is in The Overworld"
+		#The second line of text under the app name
+		state = ""
+		#The Asset ID of the image to display as the large image
+		largeImageKey = "overworld"
+		#The text that gets displayed when the large image is hovered
+		largeImageText = "In the Overworld"
+		#The Asset ID of the image to display as the small image
+		smallImageKey = "mclogo"
+		#The text that gets displayed when the small image is hovered
+		smallImageText = "%mods% mods installed"
+		#The buttons to display on Discord
+		buttons = []
+
+	[[dimension_overrides.dimensions]]
+		#The name of the Dimension/Biome to override. FORMAT: modid:dimension or modid:biome
+		name = "the_nether"
+		#The first line of text under the app name
+		description = "%player% is in The Nether"
+		#The second line of text under the app name
+		state = ""
+		#The Asset ID of the image to display as the large image
+		largeImageKey = "nether"
+		#The text that gets displayed when the large image is hovered
+		largeImageText = "In the Nether"
+		#The Asset ID of the image to display as the small image
+		smallImageKey = "mclogo"
+		#The text that gets displayed when the small image is hovered
+		smallImageText = "%mods% mods installed"
+		#The buttons to display on Discord
+		buttons = []
+
+	[[dimension_overrides.dimensions]]
+		#The name of the Dimension/Biome to override. FORMAT: modid:dimension or modid:biome
+		name = "the_end"
+		#The first line of text under the app name
+		description = "%player% is in The End"
+		#The second line of text under the app name
+		state = ""
+		#The Asset ID of the image to display as the large image
+		largeImageKey = "end"
+		#The text that gets displayed when the large image is hovered
+		largeImageText = "In the End"
+		#The Asset ID of the image to display as the small image
+		smallImageKey = "mclogo"
+		#The text that gets displayed when the small image is hovered
+		smallImageText = "%mods% mods installed"
+		#The buttons to display on Discord
+		buttons = []


### PR DESCRIPTION
## What
Adds a mod that adds discord's rich presence to Supersymmetry.

## Implementation Details
Some rich presence events are disabled for the sake of simplicity.
Enabled are: Loading Screen, Main Menu, Singleplayer and Multiplayer.
Also, dimension specific events can be added if desired.

## Outcome
Modified `manifest.json` (`Supersymmetry`) by adding the entry for the new mod.
Added two files in `Supersymmetry\simple-rpc` (includes config file).

## Additional Information
The Discord Dev project id / Application ID currently used is by a project owned by my discord account. In the future it could be replaced by a project Zalgo owns.

## Examples
![Discord RP Example #1](https://github.com/SymmetricDevs/Supersymmetry/assets/81928868/f8ae67a4-5cf6-4cc0-87a4-3bc320d83dd6)
![Discord RP Example #2](https://github.com/SymmetricDevs/Supersymmetry/assets/81928868/840ba433-5f29-4ed2-a014-39c57190d86b)
![Discord RP Example #3](https://github.com/SymmetricDevs/Supersymmetry/assets/81928868/98ade4e5-5600-46f8-8a0f-7a039212d23e)
![Discord RP Example #4](https://github.com/SymmetricDevs/Supersymmetry/assets/81928868/c00d1758-5a2f-4a73-aa59-fbf4134e9597)