### PR TITLE
Fix a quest's title

### DIFF
--- a/config/betterquesting/resources/supersymmetry/lang/en_us.lang
+++ b/config/betterquesting/resources/supersymmetry/lang/en_us.lang
@@ -244,7 +244,7 @@ susy.quest.db.93.title=Balanced Bucket
 susy.quest.db.93.desc=Iron buckets§r aren't available yet, so they must be made with clay. %n%nUse a §6Clay Tool §r[§aRight Click§r] on clay to get the bucket. Make sure to then break it with a §6§6§6shovel§6§f, not your hand, or it will drop nothing.%n%nYou should also make sure it isn't a Clay Large or Clay Small Vessel first. %n%nAfter obtaining the bucket, smelt it in a furnace to fire it and get a §cCeramic Bucket§r.
 susy.quest.db.94.title=Steam Motor
 susy.quest.db.94.desc=§6Steam Motors §rrequire two Pistons to function. They are required to create trains.
-susy.quest.db.95.title=Steam Pumps
+susy.quest.db.95.title=Steam Pump
 susy.quest.db.95.desc=§6Steam Pumps §rmove liquid around. They will be required to create a Vacuum Chamber.%n%nIt also acts as a cover and it extracts fluids from tanks or things that don't auto output (like steam machines).%n%n§6Covers §rare ways to give your machines extra behavior without using any extra block space. Covers are placed by §aright-click§ring the item on a face of a machine, and they can be removed by using a §6Crowbar§r. %n%n§6Pumps, Robot Arms and Conveyor Modules are all Covers§r.%n%nIf you are confused about covers, watch this video: §9https://www.youtube.com/watch?v=0RsPoXjUags §r(Link doesn't work)
 susy.quest.db.96.title=Enhanced Flint Tools
 susy.quest.db.96.desc=You can build a better §6flint axe§r that chops down an entire tree in one hit, and a better §7§6flint pick §rthat automatically places Torches if you [§aRight Click§r].


### PR DESCRIPTION
## What
Change quest 95's title from "Steam Pumps" to "Steam Pump".

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->
Edited `en_us.lang` (`Supersymmetry\config\betterquesting\resources\supersymmetry\lang`).