### PR TITLE
Add Discord RP mod's config to the pack exporter

### DIFF
--- a/build/main.py
+++ b/build/main.py
@@ -34,7 +34,7 @@ def build(args):
     modlist = []
     basePath = os.path.normpath(os.path.realpath(__file__)[:-7] + "..")
     copyDirs = ["/scripts", "/resources", "/config",
-                "/mods", "/structures", "/groovy"]
+                "/mods", "/structures", "/groovy", "/simple-rpc"]
     serverCopyDirs = ["/scripts", "/config", "/mods", "/structures", "/groovy"]
 
     if args.clean:


### PR DESCRIPTION
## What
Before, the new rich presence mod didn't have it's config included in the exported pack since it sits outside the config folder (for some reason). Now, it should be fixed.

## Outcome
Edited `main.py` (`Supersymmetry\build`).