### PR TITLE
Turn off edit mode :)

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -44344,6 +44344,7 @@
   },
   "questSettings:10": {
     "betterquesting:10": {
+      "editmode:1": 0,
       "hardcore:1": 0,
       "home_anchor_x:5": 0.5,
       "home_anchor_y:5": 0.0,


### PR DESCRIPTION
Technically, a fuller fix would involve changing the quest condenser to actually prevent this in the future, as a certain someone (cough cough) made "editmode:1"=1 gets automatically stripped and hidden, as it's technically a "default" value, rather than fixing it directly.