### PR TITLE
Main menu localisation [DE]

### DIFF
--- a/config/CustomMainMenu/mainmenu.json
+++ b/config/CustomMainMenu/mainmenu.json
@@ -61,7 +61,7 @@
 			"height": 20,
 			"imageWidth": 200,
 			"imageHeight": 20,
-			"tooltip": "§a#modsactive#§r/§e#modsloaded#§7 mods loaded.§r",
+			"tooltip": "susy.menu.mods.tooltip",
 			"texture": "supersymmetry:mainmenu/button.png",
 			"hoverTextColor": 65484,
 			"clickSound": "block.lever.click",
@@ -89,7 +89,7 @@
 		},
 		"quit": {
 			"text": "menu.quit",
-			"hoverText": "You can never escape Greg.",
+			"hoverText": "susy.menu.quit.hover",
 			"alignment": "center",
 			"posX": -150,
 			"posY": 55,

--- a/config/CustomMainMenu/mainmenu.json
+++ b/config/CustomMainMenu/mainmenu.json
@@ -61,7 +61,7 @@
 			"height": 20,
 			"imageWidth": 200,
 			"imageHeight": 20,
-			"tooltip": "susy.menu.mods.tooltip",
+			"tooltip": "§a#modsactive#§r/§e#modsloaded#§r",
 			"texture": "supersymmetry:mainmenu/button.png",
 			"hoverTextColor": 65484,
 			"clickSound": "block.lever.click",

--- a/resources/langfiles/lang/de_de.lang
+++ b/resources/langfiles/lang/de_de.lang
@@ -1,6 +1,5 @@
 # Main Menu
 fml.menu.mods=Modifizierungen
-susy.menu.mods.tooltip=§a#modsactive#§r/§e#modsloaded#§7 Modifizierungen geladen.§r
 susy.menu.options=Einstellungen
 susy.menu.discord=Discord-Server
 susy.menu.reportabug=Spielfehler melden

--- a/resources/langfiles/lang/de_de.lang
+++ b/resources/langfiles/lang/de_de.lang
@@ -5,5 +5,5 @@ susy.menu.discord=Discord-Server
 susy.menu.reportabug=Spielfehler melden
 susy.menu.openfolder=Minecraft-Ordner öffnen
 susy.menu.refresh=Menü aktualisieren
-susy.menu.replayviewer=Wiederholungen
+susy.menu.replayviewer=Aufnahmen
 susy.menu.quit.hover=Du kannst GregTech nicht entkommen.

--- a/resources/langfiles/lang/de_de.lang
+++ b/resources/langfiles/lang/de_de.lang
@@ -1,0 +1,10 @@
+# Main Menu
+fml.menu.mods=Modifizierungen
+susy.menu.mods.tooltip=§a#modsactive#§r/§e#modsloaded#§7 Modifizierungen geladen.§r
+susy.menu.options=Einstellungen
+susy.menu.discord=Discord-Server
+susy.menu.reportabug=Spielfehler melden
+susy.menu.openfolder=Minecraft-Ordner öffnen
+susy.menu.refresh=Menü aktualisieren
+susy.menu.replayviewer=Wiederholungen
+susy.menu.quit.hover=Du kannst GregTech nicht entkommen.

--- a/resources/langfiles/lang/en_us.lang
+++ b/resources/langfiles/lang/en_us.lang
@@ -2338,9 +2338,11 @@ gregtech.block_group_members.extractable_logs_2.name=Acacia and Dark Oak
 gregtech.block_group_members.latex_logs.name=Rubber Log
 
 # Main Menu
+susy.menu.mods.tooltip=§a#modsactive#§r/§e#modsloaded#§7 mods loaded.§r
 susy.menu.options=Options
 susy.menu.discord=Discord Server
 susy.menu.reportabug=Report A Bug
 susy.menu.openfolder=Open MC Folder
 susy.menu.refresh=Refresh Menu
 susy.menu.replayviewer=Replay Viewer
+susy.menu.quit.hover=You can never escape Greg.

--- a/resources/langfiles/lang/en_us.lang
+++ b/resources/langfiles/lang/en_us.lang
@@ -2338,7 +2338,6 @@ gregtech.block_group_members.extractable_logs_2.name=Acacia and Dark Oak
 gregtech.block_group_members.latex_logs.name=Rubber Log
 
 # Main Menu
-susy.menu.mods.tooltip=§a#modsactive#§r/§e#modsloaded#§7 mods loaded.§r
 susy.menu.options=Options
 susy.menu.discord=Discord Server
 susy.menu.reportabug=Report A Bug


### PR DESCRIPTION
## What
Translation of the new Main Menu localisation keys to German.
The "You can't escape Greg" text is now also translatable.

## Implementation Details
`#modsactive#` and `#modsloaded#` don't work when used in localisation string, hence I removed the "mods loaded" text from the tooltip, now only showing the mod numbers.

## Outcome
Modified `mainmenu.json` (`Supersymmetry\config\CustomMainMenu`).
Added `de_de.lang` (`Supersymmetry\resources\langfiles\lang`).
Adjusted `en_us.lang` (`Supersymmetry\resources\langfiles\lang`) for the new localisation key.

## Additional Information
<!--This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of.-->
![grafik](https://github.com/SymmetricDevs/Supersymmetry/assets/81928868/40fbdf06-90e5-48c0-8eb0-85df6bbbe650)