### PR TITLE
Fix buildscript

### DIFF
--- a/build/questbook.py
+++ b/build/questbook.py
@@ -191,8 +191,6 @@ def build(args):
         for i in sorted(questKeys, key=key):
             file.write(i + "=" + questKeys[i] + "\n")
 
-    input("Press Enter to exit...")
-
 
 if (__name__ == "__main__"):
     build(parse_args())


### PR DESCRIPTION
Removes a "press enter to exit" prompt in the buildscript that was preventing builds from finishing.