### PR TITLE
Fix trailing comma

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -81,6 +81,6 @@
 	{
 	  "dimension": 10,
 	  "result": "deny"
-	},
+	}
   ]
   


### PR DESCRIPTION
## What
Fixes a trailing comma in incontrol spawn.json causing parsing to fail.

## Outcome
Removes the trailing comma so JSON parsing succeeds.

