### PR TITLE
Mod updates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -412,7 +412,7 @@
     },
     {
       "projectID": 460609,
-      "fileID": 5120166,
+      "fileID": 5257348,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -187,7 +187,7 @@
     },
     {
       "projectID": 623955,
-      "fileID": 5237484,
+      "fileID": 5310089,
       "required": true
     },
     {
@@ -202,7 +202,7 @@
     },
     {
       "projectID": 319175,
-      "fileID": 4810564,
+      "fileID": 5264329,
       "required": true
     },
     {
@@ -362,7 +362,7 @@
     },
     {
       "projectID": 297038,
-      "fileID": 5236190,
+      "fileID": 5290565,
       "required": true
     },
     {
@@ -397,7 +397,7 @@
     },
     {
       "projectID": 223008,
-      "fileID": 4630537,
+      "fileID": 5274236,
       "required": true
     },
     {


### PR DESCRIPTION
## What
This pr:

- Updates:

1. OpenComputers 1,8,3 => 1.8.5
2. CraftPresence 2.3.7 => 2.3.9
3. Sledgehammer 2.0.25 => 2.0.26
4. AE2 Fluid Crafting Reworked 2.5.9-r => 2.5.12-r
5. CensoredASM 5.1.9 => 5.20

Most of these mod updates are just minor bug-fixes.

This pr exists mainly because of the recent OpenComputers update which includes lots of bugfixes.

## Potential Compatibility Issues

- This pr has been tested in client with a fresh install.
- Although not tested, it's unlikely to cause issues on ​dedicated server. If needed I can conduct a test tho.
- This pr is unlikely to corrupt existing worlds.
