### PR TITLE
Remove bad extractor recipes

### DIFF
--- a/groovy/prePostInit/ModifyRecipeMaps.groovy
+++ b/groovy/prePostInit/ModifyRecipeMaps.groovy
@@ -1,6 +1,5 @@
 package prePostInit;
 
-import java.util.ArrayList;
 import gregtech.api.GregTechAPI;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
@@ -10,7 +9,6 @@ import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtechfoodoption.recipe.GTFORecipeMaps;
-import net.minecraftforge.fluids.FluidStack;
 import supersymmetry.api.fluids.SusyFluidStorageKeys;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import static gregtech.api.recipes.RecipeMaps.*;
@@ -47,9 +45,9 @@ RecipeMaps.MIXER_RECIPES.onRecipeBuild(recipeBuilder -> {
                 .buildAndRegister();
 });
 
-GregTechAPI.materialManager.getRegisteredMaterials().stream().forEach(material -> {
+GregTechAPI.materialManager.getRegisteredMaterials().forEach(material -> {
         if (material.hasProperty(PropertyKey.FLUID) && material.getProperty(PropertyKey.FLUID).getPrimaryKey() == SusyFluidStorageKeys.SLURRY) {
-                Recipe recipe = RecipeMaps.EXTRACTOR_RECIPES.findRecipe(Integer.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(OrePrefix.dust, material)), new ArrayList<FluidStack>(), false);
+                Recipe recipe = RecipeMaps.EXTRACTOR_RECIPES.findRecipe(Integer.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(OrePrefix.dust, material)), Collections.emptyList(), false);
                 if (recipe != null) {
                         RecipeMaps.EXTRACTOR_RECIPES.removeRecipe(recipe);
                 }

--- a/groovy/prePostInit/ModifyRecipeMaps.groovy
+++ b/groovy/prePostInit/ModifyRecipeMaps.groovy
@@ -1,9 +1,17 @@
 package prePostInit;
 
+import java.util.ArrayList;
+import gregtech.api.GregTechAPI;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.GTRecipeHandler;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
+import gregtech.api.unification.material.properties.PropertyKey;
+import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtechfoodoption.recipe.GTFORecipeMaps;
+import net.minecraftforge.fluids.FluidStack;
+import supersymmetry.api.fluids.SusyFluidStorageKeys;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.recipes.GTRecipeHandler.*;
@@ -39,6 +47,14 @@ RecipeMaps.MIXER_RECIPES.onRecipeBuild(recipeBuilder -> {
                 .buildAndRegister();
 });
 
+GregTechAPI.materialManager.getRegisteredMaterials().stream().forEach(material -> {
+        if (material.hasProperty(PropertyKey.FLUID) && material.getProperty(PropertyKey.FLUID).getPrimaryKey() == SusyFluidStorageKeys.SLURRY) {
+                Recipe recipe = RecipeMaps.EXTRACTOR_RECIPES.findRecipe(Integer.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(OrePrefix.dust, material)), new ArrayList<FluidStack>(), false);
+                if (recipe != null) {
+                        RecipeMaps.EXTRACTOR_RECIPES.removeRecipe(recipe);
+                }
+        }
+});
 //Removal of certain centrifuging recipes
 
 // LPG * 370


### PR DESCRIPTION
Stops this:

![image](https://github.com/SymmetricDevs/Supersymmetry/assets/80226372/0a295781-ee9b-4b67-aab5-7e7b510f1dc9)
