### PR TITLE
Mod updates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -117,7 +117,7 @@
     },
     {
       "projectID": 557549,
-      "fileID": 5229422,
+      "fileID": 5471944,
       "required": true
     },
     {
@@ -187,7 +187,7 @@
     },
     {
       "projectID": 623955,
-      "fileID": 5310089,
+      "fileID": 5533542,
       "required": true
     },
     {
@@ -282,12 +282,12 @@
     },
     {
       "projectID": 570458,
-      "fileID": 5147702,
+      "fileID": 5411078,
       "required": true
     },
     {
       "projectID": 705000,
-      "fileID": 5138787,
+      "fileID": 5529764,
       "required": true
     },
     {
@@ -302,7 +302,7 @@
     },
     {
       "projectID": 76544,
-      "fileID": 2497541,
+      "fileID": 5538671,
       "required": true
     },
     {
@@ -367,7 +367,7 @@
     },
     {
       "projectID": 284973,
-      "fileID": 3758733,
+      "fileID": 5405050,
       "required": true
     },
     {
@@ -562,7 +562,7 @@
     },
     {
       "projectID": 871198,
-      "fileID": 5222248,
+      "fileID": 5536276,
       "required": true
     },
     {
@@ -586,8 +586,8 @@
       "required": true
     },
     {
-      "projectID": 248453,
-      "fileID": 2785465,
+      "projectID": 456403,
+      "fileID": 5519319,
       "required": true
     },
     {
@@ -602,7 +602,7 @@
     },
     {
       "projectID": 250398,
-      "fileID": 5165715,
+      "fileID": 5408385,
       "required": true
     },
     {
@@ -759,11 +759,6 @@
     {
       "projectID": 267602,
       "fileID": 2915363,
-      "required": true
-    },
-    {
-      "projectID": 229876,
-      "fileID": 2483393,
       "required": true
     },
     {


### PR DESCRIPTION
## What
This PR:

1. removes BetterFPS, ~and as a result, magicly solves GregTechCEu/GregTech#1855.~ Btw BetterFPS is quite outdated and probably give no significant gain on performance.
2. VintageFix 4.2 -> 5.1 and Universal Tweaks 1.11.0 -> 1.12.0, includes bugfixes and probably some more performance boost.
3. Had Enough Items 4.25.4 -> 4.25.5, fixes an issue on crl although we can't run on crl now...
4. Better Questing Unofficial 4.2.2 -> 4.2.3, optimizations and some new features (https://github.com/CleanroomMC/BetterQuesting/releases/tag/v4.2.3) that we might be able to use.
5. Climate Control 0.9.6 -> 0.9.8.1 bugfixes ig.
6. AE2UEL 0.56.4 -> 0.56.6 and AE2FCR 2.5.12-r -> 2.6.4-r, bugfixes.
7. Controlling -> 3.0.12.4, bugfixes. The probaby most important fix is this: (https://github.com/jaredlll08/Controlling/commit/30e47fdc851932d851a44d6c68c966fbf17076d2) :trollface: .
8. Shadowfacts' Forgelin -> Forgelin-Continuous.

## Potential Compatibility Issues
This has only been tested on new saves in single player.