### PR TITLE
Bring phase separator to lv

### DIFF
--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -907,9 +907,8 @@ crafting.addShaped("gregtech:bath_condenser", metaitem('bath_condenser'), [
 // Phase Separator
 
 crafting.addShaped("gregtech:phase_separator", metaitem('phase_separator'), [
-	[metaitem('frameStainlessSteel'), metaitem('drum.stainless_steel'), metaitem('pipeSmallFluidStainlessSteel')],
-	[metaitem('pipeSmallFluidStainlessSteel'), metaitem('hull.hv'), metaitem('pipeSmallFluidStainlessSteel')],
-	[null, null, null]
+	[metaitem('frameSteel'), metaitem('drum.steel'), metaitem('pipeSmallFluidSteel')],
+	[metaitem('pipeSmallFluidSteel'), metaitem('hull.lv'), metaitem('pipeSmallFluidSteel')]
 ])
 
 //Multiblocked Machines


### PR DESCRIPTION
## What
This PR brings phase separator to LV by removing the stainless coatings from all ingredients (real).

## Outcome
<img width="326" alt="ddef576d5c9da5d8515a525a00e417fe" src="https://github.com/user-attachments/assets/f6fcbc55-adf7-4b63-8244-2f015144dd78">

Related: https://github.com/SymmetricDevs/Supersymmetry/issues/942
