### PR TITLE
Tweak Ore Rock Sorting & Remove Unused Ores

### DIFF
--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -367,7 +367,7 @@ def alluvial_tier_3 = [
     //T1.3
     'gregtech:ore_cassiterite_0' : 10000,
     'susy:resource_block:10' : 500,
-    'susy:resource_block:11' : 7500
+    'susy:resource_block:11' : 7500,
     //T3
     'minecraft:soul_sand' : 10000,
 ];
@@ -376,7 +376,7 @@ def alluvial_tier_4 = [
     //T1.4
     'gregtech:ore_cassiterite_0' : 10000,
     'susy:resource_block:10' : 1000,
-    'susy:resource_block:11' : 10000
+    'susy:resource_block:11' : 10000,
     //T4
     'minecraft:soul_sand' : 100,
     'susy:resource_block:6' : 75000,

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -8,66 +8,79 @@ int fluid_amount = 100;
 //FORMAT: ORE NAME : CHANCE (out of 10000)
 //REBALANCING MAY BE DONE AS WE GO ON
 
+
+// #TODO: #967 Tweak all OreSorting.groovy recipes to be appropriate to their utility
 def orthomagmatic_tier_1 = [
-    'gregtech:ore_spodumene_0' : 10000,
-    'gregtech:ore_lepidolite_0' : 10000,
+    //Tier 1
+    'gregtech:ore_spodumene_0' : 5000,
+    'gregtech:ore_lepidolite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000
+    'gregtech:ore_chalcopyrite_0' : 7500,
+    'gregtech:ore_sphalerite_0' : 1000,
+    'gregtech:ore_cassiterite_0' : 8000
 ];
 
 def orthomagmatic_tier_2 = [
-    'gregtech:ore_spodumene_0' : 10000,
-    'gregtech:ore_lepidolite_0' : 10000,
-    'gregtech:ore_chromite_0' : 10000,
+    //Tier 1
+    'gregtech:ore_spodumene_0' : 5000,
+    'gregtech:ore_lepidolite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_pollucite_0' : 10000
+    'gregtech:ore_chalcopyrite_0' : 7500,
+    'gregtech:ore_sphalerite_0' : 1000,
+    'gregtech:ore_cassiterite_0' : 8000,
+    //Tier 2
+    'gregtech:ore_chromite_0' : 5000,
+    'gregtech:ore_pollucite_0' : 100
 ];
 
 def orthomagmatic_tier_3 = [
-    'gregtech:ore_spodumene_0' : 10000,
-    'gregtech:ore_lepidolite_0' : 10000,
-    'gregtech:ore_thortveitite_0' : 10000,
-    'gregtech:ore_vanadiferous_titanomagnetite_0' : 10000,
-    'gregtech:ore_perovskite_0' : 10000,
-    'minecraft:soul_sand' : 10000,
-    'gregtech:ore_chromite_0' : 10000,
+    //Tier 1
+    'gregtech:ore_spodumene_0' : 5000,
+    'gregtech:ore_lepidolite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pentlandite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_pyrochlore_0' : 10000,
-    'gregtech:ore_molybdenite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_tantalite_0' : 10000,
-    'gregtech:ore_columbite_0' : 10000,
-    'gregtech:ore_pollucite_0' : 10000
+    'gregtech:ore_chalcopyrite_0' : 7500,
+    'gregtech:ore_sphalerite_0' : 1000,
+    'gregtech:ore_cassiterite_0' : 8000,
+    //Tier 2
+    'gregtech:ore_chromite_0' : 5000,
+    'gregtech:ore_pollucite_0' : 100,
+    //T3
+    'gregtech:ore_pentlandite_0' : 6000,
+    'gregtech:ore_pyrochlore_0' : 2000,
+    'gregtech:ore_molybdenite_0' : 1000,
+    'gregtech:ore_tantalite_0' : 1000,
+    'gregtech:ore_columbite_0' : 500,
+    'gregtech:ore_perovskite_0' : 7500,
+    'minecraft:soul_sand' : 100,
+    'gregtech:ore_vanadiferous_titanomagnetite_0' :7500
+
+    //'gregtech:ore_thortveitite_0' : 10000,
 ];
 
 def orthomagmatic_tier_4 = [
-    'gregtech:ore_spodumene_0' : 10000,
-    'gregtech:ore_lepidolite_0' : 10000,
-    'susy:resource_block:8' : 10000,
-    'gregtech:ore_thortveitite_0' : 10000,
-    'gregtech:ore_vanadiferous_titanomagnetite_0' : 10000,
-    'gregtech:ore_perovskite_0' : 10000,
-    'minecraft:soul_sand' : 10000,
-    'gregtech:ore_baddeleyite_0' : 10000,
-    'gregtech:ore_chromite_0' : 10000,
+    //T1
+    'gregtech:ore_spodumene_0' : 5000,
+    'gregtech:ore_lepidolite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pentlandite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_pyrochlore_0' : 10000,
-    'gregtech:ore_molybdenite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_tantalite_0' : 10000,
-    'gregtech:ore_columbite_0' : 10000,
-    'gregtech:ore_pollucite_0' : 10000
+    'gregtech:ore_chalcopyrite_0' : 7500,
+    'gregtech:ore_sphalerite_0' : 1000,
+    'gregtech:ore_cassiterite_0' : 8000,
+    //T2
+    'gregtech:ore_chromite_0' : 5000,
+    'gregtech:ore_pollucite_0' : 100,
+    //T3
+     'gregtech:ore_pentlandite_0' : 6000,
+    'gregtech:ore_pyrochlore_0' : 2000,
+    'gregtech:ore_molybdenite_0' : 1000,
+    'gregtech:ore_tantalite_0' : 1000,
+    'gregtech:ore_columbite_0' : 500,
+    'gregtech:ore_perovskite_0' : 7500,
+    'minecraft:soul_sand' : 100,
+    'gregtech:ore_vanadiferous_titanomagnetite_0' :7500
+    //T4
+    'gregtech:ore_baddeleyite_0' : 200,
+    //'susy:resource_block:8' : 10000,
+    //'gregtech:ore_thortveitite_0' : 10000,
 ];
 
 def metamorphic_tier_1 = [

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -76,52 +76,58 @@ def orthomagmatic_tier_4 = [
     'gregtech:ore_columbite_0' : 500,
     'gregtech:ore_perovskite_0' : 7500,
     'minecraft:soul_sand' : 100,
-    'gregtech:ore_vanadiferous_titanomagnetite_0' :7500
+    'gregtech:ore_vanadiferous_titanomagnetite_0' :7500,
     //T4
-    'gregtech:ore_baddeleyite_0' : 200,
+    'gregtech:ore_baddeleyite_0' : 200
     //'susy:resource_block:8' : 10000,
     //'gregtech:ore_thortveitite_0' : 10000,
 ];
 
 def metamorphic_tier_1 = [
+    //T1
+    'gregtech:ore_arsenopyrite_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2500
+    'gregtech:ore_cobaltite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
+    'gregtech:ore_pyrargyrite_0' : 5000,
     'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_pyrargyrite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_tetrahedrite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000
+    'gregtech:ore_realgar_0' : 7500,
+    'gregtech:ore_redstone_0' : 7500,
+    'gregtech:ore_tetrahedrite_0' : 9000
 ];
 
 def metamorphic_tier_2 = [
-    'gregtech:ore_magnesite_0' : 10000,
+        //T1
+    'gregtech:ore_arsenopyrite_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2500,
+    'gregtech:ore_cobaltite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
+    'gregtech:ore_pyrargyrite_0' : 5000,
     'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_pyrargyrite_0' : 10000,
-    'gregtech:ore_stephanite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_tetrahedrite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000
+    'gregtech:ore_realgar_0' : 7500,
+    'gregtech:ore_redstone_0' : 7500,
+    'gregtech:ore_tetrahedrite_0' : 9000,
+    //T2
+    'gregtech:ore_stephanite_0' : 5000,
+    'gregtech:ore_magnesite_0' : 7500
 ];
 
 def metamorphic_tier_3 = [
-    'gregtech:ore_magnesite_0' : 10000,
-    'gregtech:ore_ilmenite_0' : 10000,
+    //T1
+    'gregtech:ore_arsenopyrite_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2500,
+    'gregtech:ore_cobaltite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
+    'gregtech:ore_pyrargyrite_0' : 5000,
     'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_pyrargyrite_0' : 10000,
-    'gregtech:ore_stephanite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_tetrahedrite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000
+    'gregtech:ore_realgar_0' : 7500,
+    'gregtech:ore_redstone_0' : 7500,
+    'gregtech:ore_tetrahedrite_0' : 9000,
+    //T2
+    'gregtech:ore_stephanite_0' : 5000,
+    'gregtech:ore_magnesite_0' : 7500,
+    //T3
+    'gregtech:ore_ilmenite_0' : 5000
 ];
 
 def sedimentary_tier_1 = [

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -349,29 +349,37 @@ def hydrothermal_tier_4 = [
 ];
 
 def alluvial_tier_1 = [
-    'gregtech:ore_cassiterite_0' : 10000
+    //T1
+    'gregtech:ore_cassiterite_0' : 9500,
+    'susy:resource_block:10' : 100,
+    'susy:resource_block:11' : 1000
 ];
 
 def alluvial_tier_2 = [
+    //T1.2
     'gregtech:ore_cassiterite_0' : 10000,
-    'susy:resource_block:10' : 100,
+    'susy:resource_block:10' : 200,
     'susy:resource_block:11' : 5000
 ];
 
 
 def alluvial_tier_3 = [
-    'minecraft:soul_sand' : 10000,
+    //T1.3
     'gregtech:ore_cassiterite_0' : 10000,
-    'susy:resource_block:10' : 100,
-    'susy:resource_block:11' : 5000
+    'susy:resource_block:10' : 500,
+    'susy:resource_block:11' : 7500
+    //T3
+    'minecraft:soul_sand' : 10000,
 ];
 
 def alluvial_tier_4 = [
-    'susy:resource_block:6' : 10000,
-    'minecraft:soul_sand' : 10000,
+    //T1.4
     'gregtech:ore_cassiterite_0' : 10000,
-    'susy:resource_block:10' : 10000,
+    'susy:resource_block:10' : 1000,
     'susy:resource_block:11' : 10000
+    //T4
+    'minecraft:soul_sand' : 100,
+    'susy:resource_block:6' : 75000,
 ];
 
 //FORMAT: BASE ROCK, WASHING FLUID, WASTE FLUID, ORE OUTPUT LISTS, STARTING VOLTAGE TIER

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -265,77 +265,87 @@ def magmatic_hydrothermal_tier_4 = [
 ];
 
 def hydrothermal_tier_1 = [
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_bornite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_proustite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_acanthite_0' : 10000,
-    'gregtech:ore_stibnite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_galena_0' : 10000
+    //T1
+    'gregtech:ore_acanthite_0' : 5000,
+    'gregtech:ore_arsenopyrite_0' : 1500,
+    'gregtech:ore_bornite_0' : 7500,
+    'gregtech:ore_cassiterite_0' : 2500,
+    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cobaltite_0' : 1500,
+    'gregtech:ore_fluorite_0' : 1000,
+    'gregtech:ore_galena_0' : 7500,
+    'gregtech:ore_proustite_0' : 7500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 1000,
+    'gregtech:ore_realgar_0' : 1500,
+    'gregtech:ore_stibnite_0' : 3333
 ];
 
 def hydrothermal_tier_2 = [
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_vanadinite_0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_bornite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_proustite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_acanthite_0' : 10000,
-    'gregtech:ore_stibnite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_galena_0' : 10000
+        //T1
+    'gregtech:ore_acanthite_0' : 7500,
+    'gregtech:ore_arsenopyrite_0' : 1500,
+    'gregtech:ore_bornite_0' : 7500,
+    'gregtech:ore_cassiterite_0' : 2500,
+    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cobaltite_0' : 1500,
+    'gregtech:ore_fluorite_0' : 2500,
+    'gregtech:ore_galena_0' : 7500,
+    'gregtech:ore_proustite_0' : 9500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 1000,
+    'gregtech:ore_realgar_0' : 1500,
+    'gregtech:ore_stibnite_0' : 3333,
+    //T2
+    'gregtech:ore_vanadinite_0' : 5000
 ];
 
 def hydrothermal_tier_3 = [
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_vanadinite_0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_bornite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_proustite_0' : 10000,
-    'gregtech:ore_strontianite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_acanthite_0' : 10000,
-    'gregtech:ore_stibnite_0' : 10000,
-    'gregtech:ore_witherite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_galena_0' : 10000,
-    'gregtech:ore_bismuthinite_0' : 10000
+        //T1
+    'gregtech:ore_acanthite_0' : 7500,
+    'gregtech:ore_arsenopyrite_0' : 1500,
+    'gregtech:ore_bornite_0' : 7500,
+    'gregtech:ore_cassiterite_0' : 2500,
+    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cobaltite_0' : 1500,
+    'gregtech:ore_fluorite_0' : 2500,
+    'gregtech:ore_galena_0' : 7500,
+    'gregtech:ore_proustite_0' : 9500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 1000,
+    'gregtech:ore_realgar_0' : 1500,
+    'gregtech:ore_stibnite_0' : 3333,
+    //T2
+    'gregtech:ore_vanadinite_0' : 5000,
+    //T3
+    'gregtech:ore_witherite_0' : 2500,
+    'gregtech:ore_bismuthinite_0' : 7500
+    //'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
 ];
 
 def hydrothermal_tier_4 = [
-    'gregtech:ore_fluorite_0' : 10000,
-    'susy:resource_block:9' : 10000,
-    'gregtech:ore_vanadinite_0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_bornite_0' : 10000,
-    'gregtech:ore_realgar_0' : 10000,
-    'gregtech:ore_arsenopyrite_0' : 10000,
-    'gregtech:ore_proustite_0' : 10000,
-    'gregtech:ore_strontianite_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_acanthite_0' : 10000,
-    'gregtech:ore_stibnite_0' : 10000,
-    'gregtech:ore_witherite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_galena_0' : 10000,
-    'gregtech:ore_bismuthinite_0' : 10000,
+        //T1
+    'gregtech:ore_acanthite_0' : 7500,
+    'gregtech:ore_arsenopyrite_0' : 1500,
+    'gregtech:ore_bornite_0' : 7500,
+    'gregtech:ore_cassiterite_0' : 2500,
+    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cobaltite_0' : 1500,
+    'gregtech:ore_fluorite_0' : 2500,
+    'gregtech:ore_galena_0' : 7500,
+    'gregtech:ore_proustite_0' : 9500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 1000,
+    'gregtech:ore_realgar_0' : 1500,
+    'gregtech:ore_stibnite_0' : 3333,
+    //T2
+    'gregtech:ore_vanadinite_0' : 5000,
+    //T3
+    'gregtech:ore_witherite_0' : 2500,
+    'gregtech:ore_bismuthinite_0' : 7500
+    //'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
+    //T4
+    //'susy:resource_block:9' : 10000,
 ];
 
 def alluvial_tier_1 = [

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -7,7 +7,7 @@ int fluid_amount = 100;
 
 //FORMAT: ORE NAME : CHANCE (out of 10000)
 //REBALANCING MAY BE DONE AS WE GO ON
-
+//Divine Ray commented out unused/worthless ores 
 
 // #TODO: #967 Tweak all OreSorting.groovy recipes to be appropriate to their utility
 def orthomagmatic_tier_1 = [
@@ -52,7 +52,7 @@ def orthomagmatic_tier_3 = [
     'gregtech:ore_columbite_0' : 500,
     'gregtech:ore_perovskite_0' : 7500,
     'minecraft:soul_sand' : 100,
-    'gregtech:ore_vanadiferous_titanomagnetite_0' :7500
+    'gregtech:ore_vanadiferous_titanomagnetite_0' : 7500
 
     //'gregtech:ore_thortveitite_0' : 10000,
 ];
@@ -86,7 +86,7 @@ def orthomagmatic_tier_4 = [
 def metamorphic_tier_1 = [
     //T1
     'gregtech:ore_arsenopyrite_0' : 7500,
-    'gregtech:ore_cinnabar_0' : 2500
+    'gregtech:ore_cinnabar_0' : 2500,
     'gregtech:ore_cobaltite_0' : 1000,
     'gregtech:ore_magnetite_0' : 10000,
     'gregtech:ore_pyrargyrite_0' : 5000,
@@ -131,68 +131,78 @@ def metamorphic_tier_3 = [
 ];
 
 def sedimentary_tier_1 = [
-    'gregtech:ore_coal_0' : 10000,
-    'gregtech:ore_saltpeter_0' : 10000,
-    'susy:resource_block:12' : 10000,
-    'gregtech:ore_banded_iron_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_malachite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_fluorite_0' : 10000,
-    'susy:resource_block:0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000
+    //T1
+    'gregtech:ore_banded_iron_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2000,
+    'gregtech:ore_coal_0' : 9000,
+    'gregtech:ore_fluorite_0' : 2000,
+    'gregtech:ore_malachite_0' : 2500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 5000,
+    'gregtech:ore_saltpeter_0' : 5000,
+    'susy:resource_block:0' : 7500,
+    'susy:resource_block:12' : 5000
 ];
 
 def sedimentary_tier_2 = [
-    'gregtech:ore_coal_0' : 10000,
-    'gregtech:ore_saltpeter_0' : 10000,
-    'susy:resource_block:12' : 10000,
-    'gregtech:ore_banded_iron_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_malachite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_magnesite_0' : 10000,
-    'susy:resource_block:0' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000
+    //T1
+    'gregtech:ore_banded_iron_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2000,
+    'gregtech:ore_coal_0' : 9000,
+    'gregtech:ore_fluorite_0' : 2000,
+    'gregtech:ore_malachite_0' : 2500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 5000,
+    'gregtech:ore_saltpeter_0' : 5000,
+    'susy:resource_block:0' : 7500,
+    'susy:resource_block:12' : 5000,
+    //T2
+    'gregtech:ore_magnesite_0' : 2000
 ];
 
 def sedimentary_tier_3 = [
-    'gregtech:ore_coal_0' : 10000,
-    'gregtech:ore_saltpeter_0' : 10000,
-    'susy:resource_block:12' : 10000,
-    'gregtech:ore_banded_iron_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_malachite_0' : 10000,
-    'gregtech:ore_celestine_0' : 10000,
-    'gregtech:ore_barite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_magnesite_0' : 10000,
-    'susy:resource_block:0' : 10000,
-    'gregtech:ore_ilmenite_0' : 10000,
-    'susy:resource_block:1' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000
+    //T1
+    'gregtech:ore_banded_iron_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2000,
+    'gregtech:ore_coal_0' : 9000,
+    'gregtech:ore_fluorite_0' : 2000,
+    'gregtech:ore_malachite_0' : 2500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 5000,
+    'gregtech:ore_saltpeter_0' : 5000,
+    'susy:resource_block:0' : 7500,
+    'susy:resource_block:12' : 5000,
+    //T2
+    'gregtech:ore_magnesite_0' : 2000,
+    //T3
+    'gregtech:ore_ilmenite_0' : 1000,
+    //'susy:resource_block:1' : 10000,
+    'gregtech:ore_celestine_0' : 500,
+    'gregtech:ore_barite_0' : 2500,
 ];
 
 def sedimentary_tier_4 = [
-    'gregtech:ore_coal_0' : 10000,
-    'gregtech:ore_saltpeter_0' : 10000,
-    'susy:resource_block:12' : 10000,
-    'gregtech:ore_banded_iron_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_malachite_0' : 10000,
-    'gregtech:ore_celestine_0' : 10000,
-    'gregtech:ore_barite_0' : 10000,
-    'gregtech:ore_cinnabar_0' : 10000,
-    'gregtech:ore_uraninite_0' : 10000,
-    'gregtech:ore_fluorite_0' : 10000,
-    'gregtech:ore_magnesite_0' : 10000,
-    'susy:resource_block:0' : 10000,
-    'gregtech:ore_ilmenite_0' : 10000,
-    'susy:resource_block:1' : 10000,
-    'gregtech:ore_pyrolusite_0' : 10000,
-    'gregtech:ore_carnotite_0' : 10000
+        //T1
+    'gregtech:ore_banded_iron_0' : 7500,
+    'gregtech:ore_cinnabar_0' : 2000,
+    'gregtech:ore_coal_0' : 9000,
+    'gregtech:ore_fluorite_0' : 2000,
+    'gregtech:ore_malachite_0' : 2500,
+    'gregtech:ore_pyrite_0' : 2500,
+    'gregtech:ore_pyrolusite_0' : 5000,
+    'gregtech:ore_saltpeter_0' : 5000,
+    'susy:resource_block:0' : 7500,
+    'susy:resource_block:12' : 5000,
+    //T2
+    'gregtech:ore_magnesite_0' : 2000,
+    //T3
+    'gregtech:ore_ilmenite_0' : 1000,
+    //'susy:resource_block:1' : 10000,
+    'gregtech:ore_celestine_0' : 500,
+    'gregtech:ore_barite_0' : 2500,
+    //T4
+    'gregtech:ore_carnotite_0' : 100
+    //'gregtech:ore_uraninite_0' : 750,
 ];
 
 def magmatic_hydrothermal_tier_1 = [

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -206,55 +206,62 @@ def sedimentary_tier_4 = [
 ];
 
 def magmatic_hydrothermal_tier_1 = [
-    'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_enargite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000
+    //T1
+    'gregtech:ore_cassiterite_0' : 5000,
+    'gregtech:ore_chalcopyrite_0' : 7500,
+    'gregtech:ore_cobaltite_0' : 2500,
+    'gregtech:ore_enargite_0' : 5000,
+    'gregtech:ore_magnetite_0' : 7500,
+    'gregtech:ore_pyrite_0' : 5000,
+    'gregtech:ore_redstone_0' : 2500,
+    'gregtech:ore_sphalerite_0' : 7500
 ];
 
 def magmatic_hydrothermal_tier_2 = [
-    'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_enargite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000
+    //T1 but better
+    'gregtech:ore_cassiterite_0' : 7500,
+    'gregtech:ore_chalcopyrite_0' : 5500,
+    'gregtech:ore_cobaltite_0' : 5000,
+    'gregtech:ore_enargite_0' : 7500,
+    'gregtech:ore_magnetite_0' : 9000,
+    'gregtech:ore_pyrite_0' : 7500,
+    'gregtech:ore_redstone_0' : 5000,
+    'gregtech:ore_sphalerite_0' : 9000
 ];
 
 def magmatic_hydrothermal_tier_3 = [
-    'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_enargite_0' : 10000,
-    'gregtech:ore_pyrochlore_0' : 10000,
-    'gregtech:ore_wolframite_0' : 10000,
-    'gregtech:ore_scheelite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000
+        //T1 but better
+    'gregtech:ore_cassiterite_0' : 7500,
+    'gregtech:ore_chalcopyrite_0' : 5500,
+    'gregtech:ore_cobaltite_0' : 5000,
+    'gregtech:ore_enargite_0' : 7500,
+    'gregtech:ore_magnetite_0' : 9000,
+    'gregtech:ore_pyrite_0' : 7500,
+    'gregtech:ore_pyrochlore_0' : 1000,
+    'gregtech:ore_redstone_0' : 5000,
+    'gregtech:ore_sphalerite_0' : 9000,
+    //T3
+    'gregtech:ore_scheelite_0' : 1250,
+    'gregtech:ore_wolframite_0' : 1000
 ];
 
 def magmatic_hydrothermal_tier_4 = [
-    'susy:resource_block:7' : 10000,
-    'gregtech:ore_magnetite_0' : 10000,
-    'gregtech:ore_pyrite_0' : 10000,
-    'gregtech:ore_cobaltite_0' : 10000,
-    'gregtech:ore_chalcopyrite_0' : 10000,
-    'gregtech:ore_sphalerite_0' : 10000,
-    'gregtech:ore_enargite_0' : 10000,
-    'gregtech:ore_pyrochlore_0' : 10000,
-    'gregtech:ore_wolframite_0' : 10000,
-    'gregtech:ore_scheelite_0' : 10000,
-    'gregtech:ore_redstone_0' : 10000,
-    'gregtech:ore_cassiterite_0' : 10000,
-    'gregtech:ore_uraninite_0' : 10000
+            //T1 but better
+    'gregtech:ore_cassiterite_0' : 7500,
+    'gregtech:ore_chalcopyrite_0' : 5500,
+    'gregtech:ore_cobaltite_0' : 5000,
+    'gregtech:ore_enargite_0' : 7500,
+    'gregtech:ore_magnetite_0' : 9000,
+    'gregtech:ore_pyrite_0' : 7500,
+    'gregtech:ore_pyrochlore_0' : 1000,
+    'gregtech:ore_redstone_0' : 5000,
+    'gregtech:ore_sphalerite_0' : 9000,
+    //T3
+    'gregtech:ore_scheelite_0' : 1250,
+    'gregtech:ore_wolframite_0' : 1000,
+    //T4
+    //'susy:resource_block:7' : 10000,
+    'gregtech:ore_uraninite_0' : 500
 ];
 
 def hydrothermal_tier_1 = [

--- a/groovy/postInit/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/metallurgy/OreSorting.groovy
@@ -270,7 +270,7 @@ def hydrothermal_tier_1 = [
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
     'gregtech:ore_cassiterite_0' : 2500,
-    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cinnabar_0' : 3333,
     'gregtech:ore_cobaltite_0' : 1500,
     'gregtech:ore_fluorite_0' : 1000,
     'gregtech:ore_galena_0' : 7500,
@@ -287,7 +287,7 @@ def hydrothermal_tier_2 = [
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
     'gregtech:ore_cassiterite_0' : 2500,
-    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cinnabar_0' : 3333,
     'gregtech:ore_cobaltite_0' : 1500,
     'gregtech:ore_fluorite_0' : 2500,
     'gregtech:ore_galena_0' : 7500,
@@ -306,7 +306,7 @@ def hydrothermal_tier_3 = [
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
     'gregtech:ore_cassiterite_0' : 2500,
-    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cinnabar_0' : 3333,
     'gregtech:ore_cobaltite_0' : 1500,
     'gregtech:ore_fluorite_0' : 2500,
     'gregtech:ore_galena_0' : 7500,
@@ -329,7 +329,7 @@ def hydrothermal_tier_4 = [
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
     'gregtech:ore_cassiterite_0' : 2500,
-    'gregtech:ore_cinnabar_0' : 33333,
+    'gregtech:ore_cinnabar_0' : 3333,
     'gregtech:ore_cobaltite_0' : 1500,
     'gregtech:ore_fluorite_0' : 2500,
     'gregtech:ore_galena_0' : 7500,
@@ -369,7 +369,7 @@ def alluvial_tier_3 = [
     'susy:resource_block:10' : 500,
     'susy:resource_block:11' : 7500,
     //T3
-    'minecraft:soul_sand' : 10000,
+    'minecraft:soul_sand' : 100
 ];
 
 def alluvial_tier_4 = [
@@ -379,7 +379,7 @@ def alluvial_tier_4 = [
     'susy:resource_block:11' : 10000,
     //T4
     'minecraft:soul_sand' : 100,
-    'susy:resource_block:6' : 75000,
+    'susy:resource_block:6' : 7500
 ];
 
 //FORMAT: BASE ROCK, WASHING FLUID, WASTE FLUID, ORE OUTPUT LISTS, STARTING VOLTAGE TIER


### PR DESCRIPTION
This PR modifies the ore rock sorting to be biased (respecting rarity and usability).
Additionally, some unused or orphaned ores have been commented out.  