### PR TITLE
Use our own implementation of finite water

### DIFF
--- a/config/Universal Tweaks - Tweaks.cfg
+++ b/config/Universal Tweaks - Tweaks.cfg
@@ -124,7 +124,7 @@ general {
 
         "finite water" {
             # Prevents creation of infinite water sources
-            B:"[1] Finite Water Toggle"=true
+            B:"[1] Finite Water Toggle"=false
 
             # Allows creation of infinite water sources in ocean and river biomes
             B:"[2] Allow Water Biomes"=true

--- a/groovy/postInit/gameplay/FiniteWater.groovy
+++ b/groovy/postInit/gameplay/FiniteWater.groovy
@@ -7,6 +7,9 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
+/**
+ * Adapted from UniversalTweaks
+ **/
 event_manager.listen { BlockEvent.CreateFluidSourceEvent event ->
     World world = event.getWorld();
     BlockPos pos = event.getPos();

--- a/groovy/postInit/gameplay/FiniteWater.groovy
+++ b/groovy/postInit/gameplay/FiniteWater.groovy
@@ -1,0 +1,23 @@
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+event_manager.listen { BlockEvent.CreateFluidSourceEvent event ->
+    World world = event.getWorld();
+    BlockPos pos = event.getPos();
+    if (pos.getY() > 63) {
+        event.setResult(Event.Result.DENY);
+        return;
+    }
+    Biome biome = world.getBiomeForCoordsBody(pos);
+    if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(biome, BiomeDictionary.Type.RIVER)) return;
+    IBlockState state = event.getState();
+    if (state.getMaterial() == Material.WATER) {
+        event.setResult(Event.Result.DENY)
+    }
+}

--- a/groovy/postInit/gameplay/FiniteWater.groovy
+++ b/groovy/postInit/gameplay/FiniteWater.groovy
@@ -15,7 +15,9 @@ event_manager.listen { BlockEvent.CreateFluidSourceEvent event ->
         return;
     }
     Biome biome = world.getBiomeForCoordsBody(pos);
-    if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.OCEAN) || BiomeDictionary.hasType(biome, BiomeDictionary.Type.RIVER)) return;
+    if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.OCEAN)
+            || BiomeDictionary.hasType(biome, BiomeDictionary.Type.RIVER)
+            || BiomeDictionary.hasType(biome, BiomeDictionary.Type.BEACH)) return;
     IBlockState state = event.getState();
     if (state.getMaterial() == Material.WATER) {
         event.setResult(Event.Result.DENY)


### PR DESCRIPTION
## What
Since https://github.com/SymmetricDevs/Supersymmetry/pull/945, we have adapted to use finite water feature provided by universal tweaks. However, it uses a `OR` logic between height limitations and biome restrictions, which I didn't notice at that time.
So, as a result, this PR serves as an in-house replacement of UTFiniteWater, which is done via event listener in a groovy script.

## Implementation Details
Mostly indentical to what UTFiniteWater does, just changes the `OR` logic to `AND`, and allows beaches to create infinite water as well.

## Additional Infomation
<img width="1280" alt="{53BEA105-D1C8-48ba-B550-97450C337FE1}" src="https://github.com/user-attachments/assets/51886f89-b354-4aa0-9733-2f182bafa329">


This PR has been tested in a client instance.