### PR TITLE
fix: build/buildOut being in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 mods/
-*buildOut/*
+buildOut/
 *client.zip
 .mixin.out/
 armourers_workshop/
@@ -8,6 +8,7 @@ fonts/
 journeymap/
 logs/
 saves/
+build/buildOut/
 
 .curseclient
 usercache.json


### PR DESCRIPTION
Correctly sets gitignore to ignore files in `build/buildOut/`.