### PR TITLE
Handles recycling via grs

### DIFF
--- a/groovy/globals/RecyclingHelper.groovy
+++ b/groovy/globals/RecyclingHelper.groovy
@@ -1,0 +1,124 @@
+package globals
+
+import com.cleanroommc.groovyscript.api.IIngredient
+import gregtech.api.recipes.RecipeMap
+import gregtech.api.recipes.ingredients.GTRecipeInput
+import gregtech.api.unification.OreDictUnifier
+import gregtech.api.unification.material.MarkerMaterial
+import gregtech.api.unification.material.Material
+import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.stack.ItemMaterialInfo
+import gregtech.api.unification.stack.MaterialStack
+import gregtech.loaders.recipe.RecyclingRecipes
+import it.unimi.dsi.fastutil.objects.Object2LongMap
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
+
+import java.util.stream.Collectors
+
+/**
+ * An utility class that handles recycling recipes,
+ * with many codes copied from CEu itself.
+ * Note: This DOES NOT work with extractor,
+ * which doesn't respect input stacks when output stack has a prefix
+ */
+class RecyclingHelper {
+
+    private static final List recyclingRecipeMaps = [
+            recipemap("macerator"),
+            recipemap("arc_furnace"),
+            recipemap("extractor")
+    ]
+
+    static final void removeByOutput(ItemStack output) {
+        crafting.removeByOutput(output)
+        removeRecyclingRecipes(output)
+    }
+
+    static final void replaceShapeless(String name, ItemStack output, List<IIngredient> inputs) {
+        crafting.replaceShapeless(name, output, inputs)
+        removeRecyclingRecipes(output)
+        handleRecycling(output, inputs)
+    }
+
+    static final void addShapeless(String name, ItemStack output, List<IIngredient> inputs) {
+        crafting.addShapeless(name, output, inputs)
+        handleRecycling(output, inputs)
+    }
+
+    static final void replaceShaped(String name, ItemStack output, List<List<IIngredient>> inputs) {
+        crafting.replaceShaped(name, output, inputs)
+        removeRecyclingRecipes(output)
+        handleRecycling(output, inputs)
+    }
+
+    static final void addShaped(String name, ItemStack output, List<List<IIngredient>> inputs) {
+        crafting.addShaped(name, output, inputs)
+        handleRecycling(output, inputs)
+    }
+
+    static final void removeRecyclingRecipes(ItemStack output) {
+        for (RecipeMap recipeMap : recyclingRecipeMaps) {
+            recipeMap.getGroovyScriptRecipeMap().streamRecipes().removeIf(recipe -> {
+                for (GTRecipeInput inputStack : recipe.getInputs()) {
+                    if (inputStack.acceptsStack(output)) {
+                        return true;
+                    }
+                }
+                return false;
+            })
+        }
+    }
+
+    static final void handleRecycling(ItemStack output, List<?> inputs) {
+        RecyclingRecipes.registerRecyclingRecipes(output.withAmount(1),
+                getRecyclingIngredients(output.getAmount(), inputs.flatten()).getMaterials(),
+                false, /*OreDictUnifier.getPrefix(output)*/ null) // See the comment at the top of this class
+    }
+
+    private static final ItemMaterialInfo getRecyclingIngredients(int outputCount, List<IIngredient> inputs) {
+
+        Object2LongMap<Material> materialStacksExploded = new Object2LongOpenHashMap<>();
+
+        for (IIngredient input : inputs) {
+            if (input == null || input.isEmpty()) continue
+            addItemStackToMaterialStacks(input.getMatchingStacks()[0], materialStacksExploded, input.getAmount())
+        }
+
+        return new ItemMaterialInfo(materialStacksExploded.entrySet().stream()
+                .map(e -> new MaterialStack(e.getKey(), e.getValue().intdiv(outputCount)))
+                .sorted(Comparator.comparingLong(m -> -m.amount))
+                .collect(Collectors.toList()));
+    }
+
+    private static final void addItemStackToMaterialStacks(ItemStack itemStack, Object2LongMap<Material> materialStacksExploded, int inputCount) {
+        // First try to get ItemMaterialInfo
+        ItemMaterialInfo info = OreDictUnifier.getMaterialInfo(itemStack);
+        if (info != null) {
+            for (MaterialStack ms : info.getMaterials()) {
+                if (!(ms.material instanceof MarkerMaterial)) {
+                    addMaterialStack(materialStacksExploded, inputCount, ms);
+                }
+            }
+            return;
+        }
+
+        // Then try to get a single Material (UnificationEntry needs this, for example)
+        MaterialStack materialStack = OreDictUnifier.getMaterial(itemStack);
+        if (materialStack != null && !(materialStack.material instanceof MarkerMaterial)) {
+            addMaterialStack(materialStacksExploded, inputCount, materialStack);
+        }
+
+        // Gather any secondary materials if this item has an OrePrefix
+        OrePrefix prefix = OreDictUnifier.getPrefix(itemStack);
+        if (prefix != null && !prefix.secondaryMaterials.isEmpty()) {
+            for (MaterialStack ms : prefix.secondaryMaterials) {
+                addMaterialStack(materialStacksExploded, inputCount, ms);
+            }
+        }
+    }
+
+    private static final void addMaterialStack(Object2LongMap<Material> materialStacksExploded, int inputCount, MaterialStack ms) {
+        long amount = materialStacksExploded.getOrDefault(ms.material, 0L);
+        materialStacksExploded.put(ms.material, (ms.amount * inputCount) + amount);
+    }
+}

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1,20 +1,10 @@
 import globals.Globals
 import globals.GroovyUtils
-
-import gregtech.api.recipes.recipeproperties.RecipeProperty;
-import gregtech.api.recipes.RecipeBuilder;
-
-import gregtech.api.recipes.ingredients.GTRecipeInput;
-import gregtech.api.recipes.ModHandler;
-import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.UnificationEntry;
-import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.blocks.MetaBlocks.*;
-
-import supersymmetry.api.capability.impl.PseudoMultiRecipeLogic;
-import supersymmetry.api.recipes.builders.PseudoMultiRecipeBuilder;
-import net.minecraft.init.Blocks;
+import globals.RecyclingHelper
+import gregtech.api.recipes.category.RecipeCategories
+import gregtech.common.blocks.MetaBlocks
+import gregtech.common.blocks.MetaBlocks.*
+import net.minecraft.init.Blocks
 
 log.infoMC("Running GregTech.groovy...")
 
@@ -219,31 +209,31 @@ mods.gregtech.assembler.removeByInput(1920, [metaitem('gemLapotron'), metaitem('
 //CONSUMES IRON BUCKET ONLY BECAUSE THE OUTPUT IS IN AN IRON BUCKET
 crafting.addShapeless('gregtech:salt_water_bucket', item('forge:bucketfilled').withNbt(["FluidName": "salt_water", "Amount": 1000]), [item('minecraft:water_bucket').noreturn(), metaitem('dustSalt'), metaitem('dustSalt')])
 
-crafting.addShaped('gregtech:pbf_bronze', metaitem('primitive_blast_furnace.bronze'), [
+RecyclingHelper.replaceShaped('gregtech:bronze_primitive_blast_furnace', metaitem('primitive_blast_furnace.bronze'), [
     [ore('craftingToolHardHammer'), ore('stickBronze'), ore('screwBronze')],
     [ore('plateBronze'), item('gregtech:metal_casing:1'), ore('stickBronze')],
     [ore('craftingToolScrewdriver'), ore('stickBronze'), ore('screwBronze')]
 ])
 
-crafting.addShaped('gregtech:high_pressure_latex_extractor', metaitem('latex_collector.steel'), [
+RecyclingHelper.addShaped('gregtech:high_pressure_latex_extractor', metaitem('latex_collector.steel'), [
         [metaitem('pipeSmallFluidSteel'), metaitem('susy:pump.steam'), metaitem('pipeSmallFluidSteel')],
         [metaitem('plateSteel'), metaitem('latex_collector.bronze'), metaitem('plateSteel')],
         [metaitem('plateWroughtIron'), metaitem('plateWroughtIron'), metaitem('plateWroughtIron')]
 ])
 
-crafting.addShaped('gregtech:steam_macerator', metaitem('steam_macerator_bronze'), [
+RecyclingHelper.replaceShaped('gregtech:steam_macerator_bronze', metaitem('steam_macerator_bronze'), [
     [metaitem('toolHeadBuzzSawSteel'), metaitem('pipeSmallFluidBronze'), metaitem('toolHeadBuzzSawSteel')],
     [metaitem('pipeSmallFluidBronze'), item('gregtech:steam_casing'), metaitem('pipeSmallFluidBronze')],
     [metaitem('steam.piston'), metaitem('pipeSmallFluidBronze'), metaitem('steam.piston')]
 ])
 
-crafting.addShaped('gregtech:co_bronze', metaitem('coke_oven'), [
+RecyclingHelper.replaceShaped('gregtech:coke_oven', metaitem('coke_oven'), [
     [item('gregtech:metal_casing:8'), ore('plateBronze'), item('gregtech:metal_casing:8')],
     [ore('plateBronze'), ore('craftingToolWrench'), ore('plateBronze')],
     [item('gregtech:metal_casing:8'), ore('plateBronze'), item('gregtech:metal_casing:8')]
 ])
 
-crafting.addShaped('gregtech:drum_wood', metaitem('drum.wood'), [
+RecyclingHelper.replaceShaped('gregtech:wooden_barrel', metaitem('drum.wood'), [
     [ore('craftingToolSoftHammer'), metaitem('rubber_drop'), ore('craftingToolSaw')],
     [ore('plankWood'), ore('stickLongBronze'), ore('plankWood')],
     [ore('plankWood'), ore('stickLongBronze'), ore('plankWood')]
@@ -256,7 +246,7 @@ crafting.addShaped("pig_iron_tiny_pile_manual", metaitem('dustTinyPigIron'), [
 
 //Steam Piston
 
-crafting.addShaped("gregtech:steam_piston", metaitem('steam.piston'), [
+RecyclingHelper.addShaped("gregtech:steam_piston", metaitem('steam.piston'), [
     [ore('plateBronze'), ore('plateBronze'), ore('plateBronze')],
     [ore('pipeTinyFluidBronze'), ore('stickBronze'), ore('stickBronze')],
     [ore('pipeTinyFluidBronze'), ore('craftingToolHardHammer'), ore('gearSmallBronze')]
@@ -274,13 +264,13 @@ mods.gregtech.assembler.recipeBuilder()
 
 //Steam Motor
 
-crafting.addShaped("gregtech:steam_motor", metaitem('steam.motor'), [
+RecyclingHelper.addShaped("gregtech:steam_motor", metaitem('steam.motor'), [
     [ore('plateBronze'), ore('stickBronze'), ore('plateBronze')],
     [metaitem('gearSmallBronze'), ore('stickBronze'), metaitem('gearSmallBronze')],
     [metaitem('steam.piston'), ore('stickBronze'), metaitem('steam.piston')]
 ]);
 
-crafting.addShaped("gregtech:steam_conveyor", metaitem('susy:conveyor.steam'), [
+RecyclingHelper.addShaped("gregtech:steam_conveyor", metaitem('susy:conveyor.steam'), [
     [ore('plateRubber'), ore('plateRubber'), ore('plateRubber')],
     [metaitem('steam.motor'), ore('gearSmallBronze'), metaitem('steam.motor')],
     [ore('plateRubber'), ore('plateRubber'), ore('plateRubber')]
@@ -296,16 +286,10 @@ mods.gregtech.assembler.recipeBuilder()
         .EUt(30)
         .buildAndRegister();
 
-crafting.addShaped("gregtech:steam_pump_iron", metaitem('susy:pump.steam'), [
+RecyclingHelper.addShaped("gregtech:steam_pump", metaitem('susy:pump.steam'), [
     [ore('screwBronze'), ore('rotorBronze'), ore('ringIron')],
     [ore('toolScrewdriver'), ore('pipeTinyFluidBronze'), ore('toolWrench')],
     [ore('ringIron'), metaitem('steam.motor'), ore('pipeTinyFluidBronze')]
-])
-
-crafting.addShaped("gregtech:steam_pump_brass", metaitem('susy:pump.steam'), [
-    [ore('screwBronze'), ore('rotorBronze'), ore('ringBrass')],
-    [ore('toolScrewdriver'), ore('pipeTinyFluidBronze'), ore('toolWrench')],
-    [ore('ringBrass'), metaitem('steam.motor'), ore('pipeTinyFluidBronze')]
 ])
 
 mods.gregtech.assembler.recipeBuilder()
@@ -322,111 +306,105 @@ mods.gregtech.assembler.recipeBuilder()
 //Steam Conveyor (no recipe for now)
 
 
-crafting.replaceShaped("gregtech:steam_extractor_bronze", metaitem('steam_extractor_bronze'), [
+RecyclingHelper.replaceShaped("gregtech:steam_extractor_bronze", metaitem('steam_extractor_bronze'), [
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')],
     [metaitem('steam.piston'), item('gregtech:steam_casing'), ore('blockGlass')],
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')]
 ])
 
-crafting.replaceShaped("gregtech:steam_vacuum_chamber", metaitem('vacuum_chamber.bronze'), [
+RecyclingHelper.replaceShaped("gregtech:steam_vacuum_chamber", metaitem('vacuum_chamber.bronze'), [
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')],
     [metaitem('susy:pump.steam'), item('gregtech:steam_casing'), ore('blockGlass')],
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')]
 ])
 
-crafting.replaceShaped('gregtech:steam_macerator_bronze', metaitem('steam_macerator_bronze'), [
-    [ore('gemDiamond'), metaitem('pipeSmallFluidBronze'), ore('gemDiamond')],
-    [metaitem('pipeSmallFluidBronze'), item('gregtech:steam_casing'), metaitem('pipeSmallFluidBronze')],
-    [metaitem('steam.piston'), metaitem('pipeSmallFluidBronze'), metaitem('steam.piston')]
-])
-
-crafting.replaceShaped("gregtech:steam_compressor_bronze", metaitem('steam_compressor_bronze'), [
+RecyclingHelper.replaceShaped("gregtech:steam_compressor_bronze", metaitem('steam_compressor_bronze'), [
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')],
     [metaitem('steam.piston'), item('gregtech:steam_casing'), metaitem('steam.piston')],
     [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')]
 ])
 
-crafting.replaceShaped("gregtech:steam_hammer_bronze", metaitem('steam_hammer_bronze'), [
+RecyclingHelper.replaceShaped("gregtech:steam_hammer_bronze", metaitem('steam_hammer_bronze'), [
     [ore('pipeSmallFluidBronze'), metaitem('steam.piston'), ore('pipeSmallFluidBronze')],
     [ore('pipeSmallFluidBronze'), item('gregtech:steam_casing'), ore('pipeSmallFluidBronze')],
     [ore('pipeSmallFluidBronze'), ore('craftingAnvil'), ore('pipeSmallFluidBronze')]
 ])
 
-crafting.replaceShaped("gregtech:steam_rock_breaker_bronze", metaitem('steam_rock_breaker_bronze'), [
+RecyclingHelper.replaceShaped("gregtech:steam_rock_breaker_bronze", metaitem('steam_rock_breaker_bronze'), [
     [metaitem('steam.piston'), ore('pipeSmallFluidBronze'), metaitem('steam.piston')],
     [ore('pipeSmallFluidBronze'), item('gregtech:steam_casing'), ore('pipeSmallFluidBronze')],
     [ore('gemDiamond'), ore('pipeSmallFluidBronze'), ore('gemDiamond')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.lathe.lv", metaitem('gregtech:lathe.lv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.lathe.lv", metaitem('gregtech:lathe.lv'), [
     [metaitem('cableGtSingleTin'),  ore('circuitLv'), metaitem('cableGtSingleTin')],
     [metaitem('electric.motor.lv'), metaitem('gregtech:hull.lv'), metaitem('toolHeadDrillSteel')],
     [ore('circuitLv'), metaitem('cableGtSingleTin'), metaitem('electric.piston.lv')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.macerator.lv", metaitem('gregtech:macerator.lv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.macerator.lv", metaitem('gregtech:macerator.lv'), [
     [metaitem('electric.piston.lv'), metaitem('electric.motor.lv') , metaitem('toolHeadBuzzSawSteel')],
     [metaitem('cableGtSingleTin'), metaitem('cableGtSingleTin'), metaitem('gregtech:hull.lv')],
     [ore('circuitLv'), ore('circuitLv'), metaitem('cableGtSingleTin')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.cutter.lv", metaitem('gregtech:cutter.lv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.cutter.lv", metaitem('gregtech:cutter.lv'), [
     [metaitem('cableGtSingleTin'), ore('circuitLv'), item('minecraft:glass')],
 	[metaitem('conveyor.module.lv'), metaitem('gregtech:hull.lv'), metaitem('toolHeadBuzzSawSteel')],
 	[ore('circuitLv'), metaitem('cableGtSingleTin'), metaitem('electric.motor.lv')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.cutter.mv", metaitem('gregtech:cutter.mv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.cutter.mv", metaitem('gregtech:cutter.mv'), [
     [metaitem('cableGtSingleCopper'), ore('circuitMv'), item('minecraft:glass')],
 	[metaitem('conveyor.module.mv'), metaitem('gregtech:hull.mv'), metaitem('toolHeadBuzzSawAluminium')],
 	[ore('circuitMv'), metaitem('cableGtSingleCopper'), metaitem('electric.motor.mv')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.cutter.hv", metaitem('gregtech:cutter.hv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.cutter.hv", metaitem('gregtech:cutter.hv'), [
     [metaitem('cableGtSingleGold'), ore('circuitHv'), item('gregtech:transparent_casing')],
 	[metaitem('conveyor.module.hv'), metaitem('gregtech:hull.hv'), metaitem('toolHeadBuzzSawVanadiumSteel')],
 	[ore('circuitHv'), metaitem('cableGtSingleGold'), metaitem('electric.motor.hv')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.electrolyzer.lv", metaitem('gregtech:electrolyzer.lv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.electrolyzer.lv", metaitem('gregtech:electrolyzer.lv'), [
 		[metaitem('wireGtSingleSilver'), item('minecraft:glass'), metaitem('wireGtSingleSilver')],
 		[metaitem('wireGtSingleSilver'), metaitem('gregtech:hull.lv'), metaitem('wireGtSingleSilver')],
 		[ore('circuitLv'), metaitem('cableGtSingleTin'), ore('circuitLv')]
 ])
 
-crafting.replaceShaped("gregtech:gregtech.machine.electrolyzer.mv", metaitem('gregtech:electrolyzer.mv'), [
+RecyclingHelper.replaceShaped("gregtech:gregtech.machine.electrolyzer.mv", metaitem('gregtech:electrolyzer.mv'), [
 		[metaitem('wireGtSingleGold'), item('minecraft:glass'), metaitem('wireGtSingleGold')],
 		[metaitem('wireGtSingleGold'), metaitem('gregtech:hull.mv'), metaitem('wireGtSingleGold')],
 		[ore('circuitMv'), metaitem('cableGtSingleCopper'), ore('circuitMv')]
 ])
 
 // Steam machine recipes (due to furnace removal)
-crafting.replaceShaped("gregtech:steam_boiler_coal_bronze", item('gregtech:machine', 1), [
+RecyclingHelper.replaceShaped("gregtech:steam_boiler_coal_bronze", item('gregtech:machine', 1), [
         [ore('plateBronze'), ore('plateBronze'), ore('plateBronze')],
         [ore('plateBronze'), ore('toolWrench'), ore('plateBronze')],
         [ore('blockBrick'), ore('blockBrick'), ore('blockBrick')]
 ])
 
-crafting.replaceShaped("gregtech:steam_boiler_coal_steel", item('gregtech:machine', 2), [
+RecyclingHelper.replaceShaped("gregtech:steam_boiler_coal_steel", item('gregtech:machine', 2), [
         [ore('plateSteel'), ore('plateSteel'), ore('plateSteel')],
         [ore('plateSteel'), ore('toolWrench'), ore('plateSteel')],
         [ore('blockBrick'), ore('blockBrick'), ore('blockBrick')]
 ])
 
-crafting.replaceShaped("gregtech:steam_furnace_bronze", item('gregtech:machine', 15), [
+RecyclingHelper.replaceShaped("gregtech:steam_furnace_bronze", item('gregtech:machine', 15), [
         [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')],
         [ore('pipeSmallFluidBronze'), ore('plateBronze'), ore('pipeSmallFluidBronze')],
         [ore('pipeSmallFluidBronze'), item('gregtech:steam_casing', 1), ore('pipeSmallFluidBronze')]
 ])
 
-crafting.replaceShaped("gregtech:steam_alloy_smelter_bronze", item('gregtech:machine', 17), [
+RecyclingHelper.replaceShaped("gregtech:steam_alloy_smelter_bronze", item('gregtech:machine', 17), [
         [ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')],
         [ore('plateBronze'), item('gregtech:steam_casing', 1),  ore('plateBronze')],
 		[ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze'), ore('pipeSmallFluidBronze')]
 ])
 
 // Multi smelter recipe (due to furnace removal)
-crafting.replaceShaped("gregtech:multi_furnace", item('gregtech:machine', 1006), [
+RecyclingHelper.replaceShaped("gregtech:multi_furnace", item('gregtech:machine', 1006), [
 		[ore('frameGtInvar'), ore('frameGtInvar'), ore('frameGtInvar')],
 		[ore('circuitHv'), item('gregtech:metal_casing', 2),  ore('circuitHv')],
 		[ore('cableGtSingleCopper'), ore('circuitHv'), ore('cableGtSingleCopper')]
@@ -568,7 +546,7 @@ mods.gregtech.assembler.recipeBuilder()
         .EUt(120)
         .buildAndRegister();
 
-crafting.replaceShaped('gregtech:filter_casing', item('gregtech:cleanroom_casing', 1) * 2, [
+RecyclingHelper.replaceShaped('gregtech:filter_casing', item('gregtech:cleanroom_casing', 1) * 2, [
         [item('minecraft:iron_bars'), item('minecraft:iron_bars'), item('minecraft:iron_bars')],
         [metaitem('electric.motor.mv'), metaitem('rotorSteel'), metaitem('electric.pump.mv')],
         [metaitem('frameSteel'), metaitem('hepa_filter'), metaitem('frameSteel')]
@@ -628,8 +606,9 @@ mods.gregtech.fluid_solidifier.recipeBuilder()
         .EUt(4)
         .buildAndRegister();
 
+// Home block
 crafting.replaceShaped('susy:home_block', item('susy:home_block'), [
-        [null, ore('craftingToolFile'), null],
+        [null, ore('toolHammer'), null],
         [null, ore('stoneSmooth'), null],
         [null, null, null]
 ])
@@ -638,6 +617,13 @@ crafting.addShapeless('susy:home_block_1', item('susy:home_block', 4), [item('su
 crafting.addShapeless('susy:home_block_2', item('susy:home_block', 8), [item('susy:home_block', 4)])
 crafting.addShapeless('susy:home_block_3', item('susy:home_block', 12), [item('susy:home_block', 8)])
 crafting.addShapeless('susy:home_block_4', item('susy:home_block', 0), [item('susy:home_block', 12)])
+
+// Inter-conversion using Chisel
+mods.chisel.carving.addGroup("home_blocks")
+mods.chisel.carving.addVariation("home_blocks", item('susy:home_block', 0))
+mods.chisel.carving.addVariation("home_blocks", item('susy:home_block', 4))
+mods.chisel.carving.addVariation("home_blocks", item('susy:home_block', 8))
+mods.chisel.carving.addVariation("home_blocks", item('susy:home_block', 12))
 
 // Acetone * 200
 mods.gregtech.fluid_heater.removeByInput(30, [metaitem('circuit.integrated').withNbt(["Configuration": 1])], [fluid('dissolved_calcium_acetate') * 200])
@@ -853,20 +839,22 @@ mods.gregtech.packer.recipeBuilder()
         .EUt(7)
         .buildAndRegister();
 
-crafting.addShaped('gregtech:fluid_filter_brass', metaitem('fluid_filter'), [
+RecyclingHelper.removeRecyclingRecipes(metaitem('fluid_filter'))
+
+RecyclingHelper.addShaped('gregtech:fluid_filter_brass', metaitem('fluid_filter'), [
         [ore('foilZinc'), ore('foilZinc'), ore('foilZinc')],
         [ore('foilZinc'), ore('plateBrass'), ore('foilZinc')],
         [ore('foilZinc'), ore('foilZinc'), ore('foilZinc')]
 ])
 
 // SuSy drums
-crafting.addShaped("drum_lead", metaitem('drum.lead'), [
+RecyclingHelper.addShaped("drum_lead", metaitem('drum.lead'), [
 		[null,ore('craftingToolHardHammer'),null],
 		[metaitem('plateLead'),metaitem('stickLongLead'),metaitem('plateLead')],
 		[metaitem('plateLead'),metaitem('stickLongLead'),metaitem('plateLead')]
 ])
 
-crafting.addShaped('gregtech:brass_drum', metaitem('drum.brass'), [
+RecyclingHelper.addShaped('gregtech:brass_drum', metaitem('drum.brass'), [
 		[null, ore('craftingToolHardHammer'), null],
 		[metaitem('plateBrass'), metaitem('stickLongBrass'), metaitem('plateBrass')],
 		[metaitem('plateBrass'), metaitem('stickLongBrass'), metaitem('plateBrass')]
@@ -906,7 +894,7 @@ mods.gregtech.assembler.recipeBuilder()
 		.buildAndRegister()
 
 // Electrolytic Cell
-crafting.addShaped('gregtech:electrolytic_cell', metaitem('electrolytic_cell'), [
+RecyclingHelper.addShaped('gregtech:electrolytic_cell', metaitem('electrolytic_cell'), [
         [ore('plateSteel'), ore('circuitLv'), ore('plateSteel')],
         [ore('wireGtQuadrupleTin'), metaitem('hull.lv'), ore('wireGtQuadrupleTin')],
         [ore('circuitLv'), ore('cableGtSingleTin'), ore('circuitLv')]
@@ -1011,7 +999,7 @@ CENTRIFUGE.recipeBuilder()
 // Fix distillation tower being too difficult (4 EV circuits? Seriously?)
 
 
-crafting.replaceShaped('gregtech:distillation_tower', metaitem('distillation_tower'), [
+RecyclingHelper.replaceShaped('gregtech:distillation_tower', metaitem('distillation_tower'), [
         [ore('circuitHv'), metaitem('pipeLargeFluidStainlessSteel'), ore('circuitHv')],
         [metaitem('electric.pump.hv'), metaitem('hull.mv'), metaitem('electric.pump.hv')],
         [ore('circuitHv'), metaitem('pipeLargeFluidStainlessSteel'), ore('circuitHv')]
@@ -1324,7 +1312,7 @@ mods.gregtech.arc_furnace.removeByInput(30, [item('gregtech:turbine_casing', 8)]
 // Solid Steel Machine Casing * 2
 mods.gregtech.assembler.removeByInput(16, [metaitem('plateSteel') * 6, metaitem('frameSteel'), metaitem('circuit.integrated').withNbt(["Configuration": 6])], null)
 
-crafting.replaceShaped("gregtech:casing_steel_solid", item('gregtech:metal_casing', 4) * 4, [
+RecyclingHelper.replaceShaped("gregtech:casing_steel_solid", item('gregtech:metal_casing', 4) * 4, [
         [ore('plateSteel'), ore('craftingToolHardHammer'), ore('plateSteel')],
         [ore('plateSteel'), ore('frameGtSteel'), ore('plateSteel')],
         [ore('plateSteel'), ore('craftingToolWrench'), ore('plateSteel')]
@@ -1342,11 +1330,21 @@ mods.gregtech.assembler.recipeBuilder()
 // Steel Frame Box * 1
 mods.gregtech.assembler.removeByInput(7, [metaitem('stickSteel') * 4, metaitem('circuit.integrated').withNbt(["Configuration": 4])], null)
 
-crafting.replaceShaped("gregtech:frame_steel", metaitem('frameSteel') * 4, [
+RecyclingHelper.replaceShaped("gregtech:frame_steel", metaitem('frameSteel') * 4, [
         [ore('stickSteel'), ore('stickSteel'), ore('stickSteel')],
         [ore('stickSteel'), ore('craftingToolWrench'), ore('stickSteel')],
         [ore('stickSteel'), ore('stickSteel'), ore('stickSteel')]
 ])
+
+// Steel frame recycling via an extractor
+mods.gregtech.extractor.recipeBuilder()
+		.inputs(metaitem('frameSteel'))
+		.fluidOutputs(fluid('steel') * 144)
+		.duration(56)
+		.EUt(Globals.voltAmps[2])
+		.category(RecipeCategories.EXTRACTOR_RECYCLING)
+		.buildAndRegister();
+	
 
 mods.gregtech.assembler.recipeBuilder()
         .circuitMeta(4)
@@ -1357,105 +1355,18 @@ mods.gregtech.assembler.recipeBuilder()
         .buildAndRegister()
 
 //Steel Pipe Casing
-crafting.replaceShaped("gregtech:casing_steel_pipe", item('gregtech:boiler_casing', 1) * 4, [
+RecyclingHelper.replaceShaped("gregtech:casing_steel_pipe", item('gregtech:boiler_casing', 1) * 4, [
         [ore('plateSteel'), ore('pipeNormalFluidSteel'), ore('plateSteel')],
         [ore('pipeNormalFluidSteel'), ore('frameGtSteel'), ore('pipeNormalFluidSteel')],
         [ore('plateSteel'), ore('pipeNormalFluidSteel'), ore('plateSteel')]
 ])
 
 //Steel Firebox Casing
-crafting.replaceShaped("gregtech:casing_steel_firebox", item('gregtech:boiler_firebox_casing', 1) * 4, [
+RecyclingHelper.replaceShaped("gregtech:casing_steel_firebox", item('gregtech:boiler_firebox_casing', 1) * 4, [
         [ore('plateSteel'), ore('stickSteel'), ore('plateSteel')],
         [ore('stickSteel'), ore('frameGtSteel'), ore('stickSteel')],
         [ore('plateSteel'), ore('stickSteel'), ore('plateSteel')]
 ])
-
-//Steel components recycling
-
-// Steel Dust * 4
-mods.gregtech.macerator.removeByInput(8, [item('gregtech:metal_casing', 4)], null)
-// Steel Ingot * 4
-mods.gregtech.arc_furnace.removeByInput(30, [item('gregtech:metal_casing', 4)], [fluid('oxygen') * 224])
-
-// Steel Dust * 9
-mods.gregtech.macerator.removeByInput(8, [item('gregtech:boiler_casing', 1)], null)
-// Block of Steel * 1
-mods.gregtech.arc_furnace.removeByInput(30, [item('gregtech:boiler_casing', 1)], [fluid('oxygen') * 504])
-
-// Steel Dust * 4
-mods.gregtech.macerator.removeByInput(8, [item('gregtech:boiler_firebox_casing', 1)], null)
-// Steel Ingot * 4
-mods.gregtech.arc_furnace.removeByInput(30, [item('gregtech:boiler_firebox_casing', 1)], [fluid('oxygen') * 224])
-
-// Steel Dust * 2
-mods.gregtech.macerator.removeByInput(8, [metaitem('frameSteel')], null)
-// Steel Ingot * 2
-mods.gregtech.arc_furnace.removeByInput(30, [metaitem('frameSteel')], [fluid('oxygen') * 112])
-// Steel * 288
-mods.gregtech.extractor.removeByInput(120, [metaitem('frameSteel')], null)
-
-//Solid Steel Casing
-mods.gregtech.macerator.recipeBuilder()
-        .inputs(item('gregtech:metal_casing', 4))
-        .outputs(metaitem('dustSmallSteel') * 7)
-        .duration(220)
-        .EUt(7)
-        .buildAndRegister()
-
-mods.gregtech.arc_furnace.recipeBuilder()
-        .inputs(item('gregtech:metal_casing', 4))
-        .fluidInputs(fluid('oxygen') * 224)
-        .outputs(metaitem('nuggetSteel') * 15)
-        .duration(220)
-        .EUt(30)
-        .buildAndRegister()
-
-//Steel Pipe Casing
-mods.gregtech.macerator.recipeBuilder()
-        .inputs(item('gregtech:boiler_casing', 1))
-        .outputs(metaitem('dustSteel') * 4)
-        .duration(220)
-        .EUt(7)
-        .buildAndRegister()
-
-mods.gregtech.arc_furnace.recipeBuilder()
-        .inputs(item('gregtech:boiler_casing', 1))
-        .fluidInputs(fluid('oxygen') * 504)
-        .outputs(metaitem('ingotSteel') * 4)
-        .duration(220)
-        .EUt(30)
-        .buildAndRegister()
-
-//Steel Fireboxes
-mods.gregtech.macerator.recipeBuilder()
-        .inputs(item('gregtech:boiler_firebox_casing', 1))
-        .outputs(metaitem('dustSmallSteel') * 7)
-        .duration(220)
-        .EUt(7)
-        .buildAndRegister()
-
-mods.gregtech.arc_furnace.recipeBuilder()
-        .inputs(item('gregtech:boiler_firebox_casing', 1))
-        .fluidInputs(fluid('oxygen') * 224)
-        .outputs(metaitem('nuggetSteel') * 15)
-        .duration(220)
-        .EUt(30)
-        .buildAndRegister()
-
-mods.gregtech.macerator.recipeBuilder()
-        .inputs(metaitem('frameSteel'))
-        .outputs(metaitem('dustSteel') * 1)
-        .duration(220)
-        .EUt(7)
-        .buildAndRegister()
-
-mods.gregtech.arc_furnace.recipeBuilder()
-        .inputs(metaitem('frameSteel'))
-        .fluidInputs(fluid('oxygen') * 112)
-        .outputs(metaitem('ingotSteel') * 1)
-        .duration(220)
-        .EUt(30)
-        .buildAndRegister()
 
 // Tapes
 mods.gregtech.assembler.recipeBuilder()
@@ -1546,7 +1457,7 @@ mods.gregtech.macerator.recipeBuilder()
 
 // Multiblock Builder
 
-crafting.replaceShaped("gregtech:multiblock_builder", metaitem('tool.multiblock_builder'), [
+RecyclingHelper.replaceShaped("gregtech:multiblock_builder", metaitem('tool.multiblock_builder'), [
         [ore('craftingToolWrench'), metaitem('robot.arm.ev'), metaitem('field.generator.hv')],
         [ore('screwStainlessSteel'), ore('stickPolytetrafluoroethylene'), metaitem('robot.arm.ev')],
         [ore('stickPolytetrafluoroethylene'), ore('screwStainlessSteel'), ore('craftingToolScrewdriver')]

--- a/groovy/postInit/mod/GregTechFoodOption.groovy
+++ b/groovy/postInit/mod/GregTechFoodOption.groovy
@@ -1,28 +1,23 @@
-import globals.Globals
+import globals.RecyclingHelper
+import gregtechfoodoption.utils.GTFOUtils
 
-import gregtech.api.recipes.ModHandler;
-import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.UnificationEntry;
-
-import gregtechfoodoption.utils.GTFOUtils;
-import static gregtechfoodoption.utils.GTFOUtils.*;
+import static gregtechfoodoption.utils.GTFOUtils.*
 
 // MACHINE RECIPES
 
-crafting.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.lv", metaitem('gregtechfoodoption:slicer.lv'), [
+RecyclingHelper.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.lv", metaitem('gregtechfoodoption:slicer.lv'), [
 		[metaitem('electric.piston.lv'), ore('circuitLv'), ore('cableGtSingleTin')],
 		[ore('toolHeadBuzzSawSteel'), metaitem('gregtech:hull.lv'), ore('circuitLv')],
 		[ore('plateSteel'), metaitem('conveyor.module.lv'), ore('cableGtSingleTin')]
 ])
 
-crafting.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.mv", metaitem('gregtechfoodoption:slicer.mv'), [
+RecyclingHelper.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.mv", metaitem('gregtechfoodoption:slicer.mv'), [
 		[metaitem('electric.piston.mv'), ore('circuitMv'), ore('cableGtSingleCopper')],
 		[ore('toolHeadBuzzSawAluminium'), metaitem('gregtech:hull.mv'), ore('circuitMv')],
 		[ore('plateAluminium'), metaitem('conveyor.module.mv'), ore('cableGtSingleCopper')]
 ])
 
-crafting.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.hv", metaitem('gregtechfoodoption:slicer.hv'), [
+RecyclingHelper.replaceShaped("gregtechfoodoption:gregtechfoodoption.machine.slicer.hv", metaitem('gregtechfoodoption:slicer.hv'), [
 		[metaitem('electric.piston.hv'), ore('circuitHv'), ore('cableGtSingleGold')],
 		[ore('toolHeadBuzzSawVanadiumSteel'), metaitem('gregtech:hull.hv'), ore('circuitHv')],
 		[ore('plateVanadiumSteel'), metaitem('conveyor.module.hv'), ore('cableGtSingleGold')]

--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -1,6 +1,7 @@
 import globals.Globals
-import static gregtech.api.unification.material.Materials.*;
-import gregtech.api.unification.material.MarkerMaterials;
+import globals.RecyclingHelper
+
+import static gregtech.api.unification.material.Materials.*
 
 def name_removals = [
 		'gregtech:steam_turbine_mv',
@@ -139,27 +140,27 @@ def tieredMagnets = [metaitem('stickIronMagnetic'), metaitem('stickIronMagnetic'
 log.infoMC("Adding Vulcanizing Press Craft")
 
 //Vulcanizing Press
-crafting.addShaped("gregtech:vulcanizing_press.ulv", metaitem('vulcanizing_press.bronze'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.ulv", metaitem('vulcanizing_press.bronze'), [
 	[ore('springSmallSteel'), ore('stickSteel'), ore('springSmallSteel')],
 	[ore('pipeSmallFluidBronze'), ore('plateSteel'), ore('pipeSmallFluidBronze')],
 	[ore('pipeSmallFluidBronze'), item('gregtech:steam_casing', 1), ore('pipeSmallFluidBronze')]
 ])
-crafting.addShaped("gregtech:vulcanizing_press.lv", metaitem('vulcanizing_press.lv'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.lv", metaitem('vulcanizing_press.lv'), [
 	[ore('cableGtSingleTin'), metaitem('electric.piston.lv'), ore('cableGtSingleTin')],
 	[ore('wireGtQuadrupleCopper'), metaitem('hull.lv'), ore('wireGtQuadrupleCopper')],
 	[ore('cableGtSingleTin'), ore('circuitLv'), ore('cableGtSingleTin')]
 ])
-crafting.addShaped("gregtech:vulcanizing_press.mv", metaitem('vulcanizing_press.mv'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.mv", metaitem('vulcanizing_press.mv'), [
 	[ore('cableGtSingleCopper'), metaitem('electric.piston.mv'), ore('cableGtSingleCopper')],
 	[ore('wireGtQuadrupleCupronickel'), metaitem('hull.mv'), ore('wireGtQuadrupleCupronickel')],
 	[ore('cableGtSingleCopper'), ore('circuitMv'), ore('cableGtSingleCopper')]
 ])
-crafting.addShaped("gregtech:vulcanizing_press.hv", metaitem('vulcanizing_press.hv'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.hv", metaitem('vulcanizing_press.hv'), [
 	[ore('cableGtSingleGold'), metaitem('electric.piston.hv'), ore('cableGtSingleGold')],
 	[ore('wireGtQuadrupleKanthal'), metaitem('hull.hv'), ore('wireGtQuadrupleKanthal')],
 	[ore('cableGtSingleGold'), ore('circuitHv'), ore('cableGtSingleGold')]
 ])
-crafting.addShaped("gregtech:vulcanizing_press.ev", metaitem('vulcanizing_press.ev'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.ev", metaitem('vulcanizing_press.ev'), [
 	[ore('cableGtSingleAluminium'), metaitem('electric.piston.ev'), ore('cableGtSingleAluminium')],
 	[ore('wireGtQuadrupleNichrome'), metaitem('hull.ev'), ore('wireGtQuadrupleNichrome')],
 	[ore('cableGtSingleAluminium'), ore('circuitEv'), ore('cableGtSingleAluminium')]
@@ -168,14 +169,14 @@ crafting.addShaped("gregtech:vulcanizing_press.ev", metaitem('vulcanizing_press.
 log.infoMC("Adding Roaster Craft")
 
 //Roaster
-crafting.addShaped("gregtech:roaster.ulv", metaitem('roaster.bronze'), [
+RecyclingHelper.addShaped("gregtech:roaster.ulv", metaitem('roaster.bronze'), [
 	[ore('pipeSmallFluidBronze'), ore('rotorBronze'), ore('pipeSmallFluidBronze')],
 	[ore('pipeSmallFluidBronze'), ore('plateBronze'), ore('pipeSmallFluidBronze')],
 	[ore('pipeSmallFluidBronze'), item('gregtech:steam_casing', 1), ore('pipeSmallFluidBronze')]
 ])
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:roaster." + Globals.voltageTiers[i], metaitem('roaster.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:roaster." + Globals.voltageTiers[i], metaitem('roaster.' + Globals.voltageTiers[i]), [
 		[circuits[i], rotors[i], circuits[i]],
 		[tieredWires[i], hulls[i], tieredWires[i]],
 		[tieredCables[i], tieredWires[i], tieredCables[i]]
@@ -185,14 +186,14 @@ for (i = 1; i <= 8; i++) {
 log.infoMC("Adding Latex Collector Craft")
 
 //Latex Collector
-crafting.addShaped("gregtech:latex_collector.ulv", metaitem('latex_collector.bronze'), [
+RecyclingHelper.addShaped("gregtech:latex_collector.ulv", metaitem('latex_collector.bronze'), [
 	[null, ore('toolHeadDrillSteel'), null],
 	[ore('blockGlass'), ore('rotorSteel'), ore('blockGlass')],
 	[ore('pipeSmallFluidBronze'), item('gregtech:steam_casing'), ore('pipeSmallFluidBronze')]
 ])
 
 for (i = 1; i <= 4; i++) {
-	crafting.addShaped("gregtech:latex_collector." + Globals.voltageTiers[i], metaitem('latex_collector.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:latex_collector." + Globals.voltageTiers[i], metaitem('latex_collector.' + Globals.voltageTiers[i]), [
 		[circuits[i], ore('toolHeadDrillSteel'), circuits[i]],
 		[ore('blockGlass'), pumps[i], ore('blockGlass')],
 		[tieredCables[i], hulls[i], tieredCables[i]]
@@ -202,7 +203,7 @@ for (i = 1; i <= 4; i++) {
 log.infoMC("Adding Steam Mixer Craft")
 
 //Mixer
-crafting.addShaped("gregtech:mixer.ulv", metaitem('mixer.bronze'), [
+RecyclingHelper.addShaped("gregtech:mixer.ulv", metaitem('mixer.bronze'), [
 	[ore('blockGlass'), ore('rotorBronze'), ore('blockGlass')],
 	[ore('blockGlass'), ore('stickBronze'), ore('blockGlass')],
 	[ore('pipeSmallFluidBronze'), item('gregtech:steam_casing'), ore('pipeSmallFluidBronze')]
@@ -211,12 +212,12 @@ crafting.addShaped("gregtech:mixer.ulv", metaitem('mixer.bronze'), [
 log.infoMC("Adding Coagulation Tank Craft")
 
 //Coagulation Tank
-crafting.addShaped("gregtech:coagulation_tank", metaitem('coagulation_tank'), [
+RecyclingHelper.addShaped("gregtech:coagulation_tank", metaitem('coagulation_tank'), [
 	[ore('plankTreatedWood'), ore('rotorSteel'), ore('plankTreatedWood')],
 	[ore('craftingToolSaw'), ore('pipeLargeFluidTreatedWood'), ore('craftingToolHardHammer')],
 	[ore('plankTreatedWood'), ore('boltSteel'), ore('plankTreatedWood')]
 ])
-crafting.addShaped("gregtech:coagulation_tank_wall", item('susy:coagulation_tank_wall'), [
+RecyclingHelper.addShaped("gregtech:coagulation_tank_wall", item('susy:coagulation_tank_wall'), [
 	[ore('plankTreatedWood'), ore('boltSteel'), ore('plankTreatedWood')],
 	[ore('craftingToolSaw'), ore('frameGtTreatedWood'), ore('craftingToolHardHammer')],
 	[ore('plankTreatedWood'), ore('boltSteel'), ore('plankTreatedWood')]
@@ -281,9 +282,9 @@ recipemap('sintering_oven').recipeBuilder()
 
 
 for (i = 1; i <= 8; i++) {
-	crafting.remove('gregtech:gregtech.machine.arc_furnace.' + Globals.voltageTiers[i])
+	RecyclingHelper.removeByOutput(metaitem('arc_furnace.' + Globals.voltageTiers[i]))
 
-	crafting.addShaped("gregtech:arc_furnace." + Globals.voltageTiers[i], metaitem('arc_furnace.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:arc_furnace." + Globals.voltageTiers[i], metaitem('arc_furnace.' + Globals.voltageTiers[i]), [
 			[tieredQuadCables[i], metaitem('graphite_electrode'), tieredQuadCables[i]],
 			[circuits[i], hulls[i], circuits[i]],
 			[tieredPlates[i], tieredPlates[i], tieredPlates[i]]
@@ -295,37 +296,37 @@ for (i = 1; i <= 8; i++) {
 for (i = 1; i <= 8; i++) {
 	crafting.remove('gregtech:gregtech.machine.chemical_reactor.' + Globals.voltageTiers[i])
 
-	crafting.addShaped("gregtech:continuous_stirred_tank_reactor." + Globals.voltageTiers[i], metaitem('continuous_stirred_tank_reactor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:continuous_stirred_tank_reactor." + Globals.voltageTiers[i], metaitem('continuous_stirred_tank_reactor.' + Globals.voltageTiers[i]), [
 			[chemicalReactorParts[i], rotors[i], chemicalReactorParts[i]],
 			[tieredCables[i], motors[i], tieredCables[i]],
 			[circuits[i], hulls[i], circuits[i]]
 	])
 
-	crafting.addShaped("gregtech:batch_reactor." + Globals.voltageTiers[i], metaitem('batch_reactor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:batch_reactor." + Globals.voltageTiers[i], metaitem('batch_reactor.' + Globals.voltageTiers[i]), [
 			[tieredCables[i], pumps[i], tieredCables[i]],
 			[chemicalReactorParts[i], hulls[i], chemicalReactorParts[i]],
 			[circuits[i], tieredCables[i], circuits[i]]
 	])
 
-	crafting.addShaped("gregtech:bubble_column_reactor." + Globals.voltageTiers[i], metaitem('bubble_column_reactor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:bubble_column_reactor." + Globals.voltageTiers[i], metaitem('bubble_column_reactor.' + Globals.voltageTiers[i]), [
 			[chemicalReactorParts[i], tieredPipes[i], chemicalReactorParts[i]],
 			[tieredCables[i], pumps[i], tieredCables[i]],
 			[circuits[i], hulls[i], circuits[i]]
 	])
 
-	crafting.addShaped("gregtech:fixed_bed_reactor." + Globals.voltageTiers[i], metaitem('fixed_bed_reactor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:fixed_bed_reactor." + Globals.voltageTiers[i], metaitem('fixed_bed_reactor.' + Globals.voltageTiers[i]), [
 			[null, circuits[i], null],
 			[tieredPipes[i], pumps[i], tieredPipes[i]],
 			[tieredCables[i], hulls[i], tieredCables[i]]
 	])
 
-	crafting.addShaped("gregtech:crystallizer." + Globals.voltageTiers[i], metaitem('crystallizer.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:crystallizer." + Globals.voltageTiers[i], metaitem('crystallizer.' + Globals.voltageTiers[i]), [
 			[tieredPlates[i], tieredGlass[i], tieredPlates[i]],
 			[chemicalReactorParts[i], hulls[i], chemicalReactorParts[i]],
 			[circuits[i], pumps[i], circuits[i]]
 	])
 
-	crafting.addShaped("gregtech:trickle_bed_reactor." + Globals.voltageTiers[i], metaitem('trickle_bed_reactor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:trickle_bed_reactor." + Globals.voltageTiers[i], metaitem('trickle_bed_reactor.' + Globals.voltageTiers[i]), [
 			[tieredCables[i], pumps[i], tieredCables[i]],
 			[tieredPipes[i], hulls[i], tieredPipes[i]],
 			[circuits[i], pumps[i], circuits[i]]
@@ -334,13 +335,13 @@ for (i = 1; i <= 8; i++) {
 
 //Polymerization tank and fluidized bed reactor
 
-crafting.addShaped("gregtech:polymerization_tank", metaitem('polymerization_tank'), [
+RecyclingHelper.addShaped("gregtech:polymerization_tank", metaitem('polymerization_tank'), [
 		[tieredCables[1], motors[1], tieredCables[1]],
 		[pumps[1], rotors[1], pumps[1]],
 		[circuits[1], hulls[1], circuits[1]]
 ])
 
-crafting.addShaped("gregtech:fluidized_bed_reactor", metaitem('fluidized_bed_reactor'), [
+RecyclingHelper.addShaped("gregtech:fluidized_bed_reactor", metaitem('fluidized_bed_reactor'), [
 		[tieredCables[3], pumps[3], tieredCables[3]],
 		[metaitem('pipeLargeFluidPolytetrafluoroethylene'), hulls[3], metaitem('pipeLargeFluidPolytetrafluoroethylene')],
 		[circuits[3], motors[3], circuits[3]]
@@ -349,7 +350,7 @@ crafting.addShaped("gregtech:fluidized_bed_reactor", metaitem('fluidized_bed_rea
 //Dryer
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:dryer." + Globals.voltageTiers[i], metaitem('dryer.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:dryer." + Globals.voltageTiers[i], metaitem('dryer.' + Globals.voltageTiers[i]), [
 			[tieredCables[i], circuits[i], tieredCables[i]],
 			[tieredSprings[i], hulls[i], tieredSprings[i]],
 			[tieredCables[i], circuits[i], tieredCables[i]]
@@ -359,7 +360,7 @@ for (i = 1; i <= 8; i++) {
 //Weapons Factory
 
 for (def i = 1; i < 8; i++) {
-	crafting.addShaped("gregtech:weapons_factory." + i, metaitem('weapons_factory.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:weapons_factory." + i, metaitem('weapons_factory.' + Globals.voltageTiers[i]), [
 			[circuits[i], robotArms[i], circuits[i]],
 			[conveyors[i], hulls[i], conveyors[i]],
 			[tieredCables[i], circuits[i], tieredCables[i]]
@@ -369,13 +370,13 @@ for (def i = 1; i < 8; i++) {
 //Fluid compressors and decompressors
 
 for (def i = 1; i < 8; i++) {
-	crafting.addShaped("gregtech:fluid_decompressor." + i, metaitem('fluid_decompressor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:fluid_decompressor." + i, metaitem('fluid_decompressor.' + Globals.voltageTiers[i]), [
 			[tieredGlass[i], pistons[i], tieredGlass[i]],
 			[pumps[i], hulls[i], tieredPipes[i]],
 			[circuits[i], tieredCables[i], circuits[i]]
 	])
 
-	crafting.addShaped("gregtech:fluid_compressor." + i, metaitem('fluid_compressor.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:fluid_compressor." + i, metaitem('fluid_compressor.' + Globals.voltageTiers[i]), [
 			[tieredGlass[i], pistons[i], tieredGlass[i]],
 			[tieredPipes[i], hulls[i], pumps[i]],
 			[circuits[i], tieredCables[i], circuits[i]]
@@ -385,13 +386,13 @@ for (def i = 1; i < 8; i++) {
 //Nerf polarizer and electromagnetic separator
 
 for (i = 1; i <= 8; i++) {
-	crafting.replaceShaped("gregtech:gregtech.machine.polarizer." + Globals.voltageTiers[i], metaitem('polarizer.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.replaceShaped("gregtech:gregtech.machine.polarizer." + Globals.voltageTiers[i], metaitem('polarizer.' + Globals.voltageTiers[i]), [
 			[tieredWires[i], tieredMagnets[i], tieredWires[i]],
 			[tieredCables[i], hulls[i], tieredCables[i]],
 			[tieredWires[i], tieredMagnets[i], tieredWires[i]]
 	])
 
-	crafting.replaceShaped("gregtech:gregtech.machine.electromagnetic_separator." + Globals.voltageTiers[i], metaitem('electromagnetic_separator.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.replaceShaped("gregtech:gregtech.machine.electromagnetic_separator." + Globals.voltageTiers[i], metaitem('electromagnetic_separator.' + Globals.voltageTiers[i]), [
 			[conveyors[i], tieredCables[i], tieredWires[i]],
 			[tieredCables[i], hulls[i], tieredMagnets[i]],
 			[circuits[i], tieredCables[i], tieredWires[i]]
@@ -405,7 +406,7 @@ def tieredElectrodes = [ore('wireFineRedAlloy'), ore('wireFineSteel'), metaitem(
 					ore('wireFineNaquadah'), ore('wireFineNaquadahAlloy')];
 
 for (i = 1; i <= 8; i++) {
-	crafting.replaceShaped("gregtech:gregtech.machine.electrostatic_separator." + Globals.voltageTiers[i], metaitem('electrostatic_separator.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.replaceShaped("gregtech:gregtech.machine.electrostatic_separator." + Globals.voltageTiers[i], metaitem('electrostatic_separator.' + Globals.voltageTiers[i]), [
 			[tieredWires[i], tieredElectrodes[i], tieredWires[i]],
 			[tieredCables[i], hulls[i], tieredCables[i]],
 			[tieredWires[i], tieredElectrodes[i], tieredWires[i]]
@@ -414,25 +415,25 @@ for (i = 1; i <= 8; i++) {
 
 //Add recipes for high pressure steam machines
 
-crafting.addShaped("gregtech:vulcanizing_press.steel", metaitem('vulcanizing_press.steel'), [
+RecyclingHelper.addShaped("gregtech:vulcanizing_press.steel", metaitem('vulcanizing_press.steel'), [
 		[metaitem('plateSteel'), metaitem('plateSteel'), metaitem('plateSteel')],
 		[metaitem('pipeSmallFluidTinAlloy'), metaitem('vulcanizing_press.bronze'), metaitem('pipeSmallFluidTinAlloy')],
 		[metaitem('plateWroughtIron'), metaitem('plateWroughtIron'), metaitem('plateWroughtIron')]
 ])
 
-crafting.addShaped("gregtech:mixer.steel", metaitem('mixer.steel'), [
+RecyclingHelper.addShaped("gregtech:mixer.steel", metaitem('mixer.steel'), [
 		[metaitem('pipeSmallFluidTinAlloy'), metaitem('plateSteel'), metaitem('pipeSmallFluidTinAlloy')],
 		[metaitem('plateWroughtIron'), metaitem('mixer.bronze'), metaitem('plateWroughtIron')],
 		[metaitem('pipeSmallFluidTinAlloy'), metaitem('pipeSmallFluidTinAlloy'), metaitem('pipeSmallFluidTinAlloy')]
 ])
 
-crafting.addShaped("gregtech:vacuum_chamber.steel", metaitem('vacuum_chamber.steel'), [
+RecyclingHelper.addShaped("gregtech:vacuum_chamber.steel", metaitem('vacuum_chamber.steel'), [
 		[metaitem('plateSteel'), metaitem('pipeSmallFluidTinAlloy'), metaitem('plateSteel')],
 		[metaitem('pipeSmallFluidTinAlloy'), metaitem('vacuum_chamber.bronze'), metaitem('pipeSmallFluidTinAlloy')],
 		[metaitem('plateWroughtIron'), metaitem('pipeSmallFluidTinAlloy'), metaitem('plateWroughtIron')]
 ])
 
-crafting.addShaped("gregtech:roaster.steel", metaitem('roaster.steel'), [
+RecyclingHelper.addShaped("gregtech:roaster.steel", metaitem('roaster.steel'), [
 		[metaitem('plateWroughtIron'), metaitem('plateWroughtIron'), metaitem('plateWroughtIron')],
 		[metaitem('plateSteel'), metaitem('roaster.bronze'), metaitem('plateSteel')],
 		[metaitem('pipeSmallFluidTinAlloy'), metaitem('pipeSmallFluidTinAlloy'), metaitem('pipeSmallFluidTinAlloy')]
@@ -441,7 +442,7 @@ crafting.addShaped("gregtech:roaster.steel", metaitem('roaster.steel'), [
 //Add the rest of the vacuum chambers
 
 for (def i = 1; i < 8; i++) {
-	crafting.addShaped("gregtech:vacuum_chamber." + i, metaitem('vacuum_chamber.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:vacuum_chamber." + i, metaitem('vacuum_chamber.' + Globals.voltageTiers[i]), [
 			[tieredPlates[i], tieredPlates[i], tieredPlates[i]],
 			[pumps[i], hulls[i], pumps[i]],
 			[tieredCables[i], circuits[i], tieredCables[i]]
@@ -450,13 +451,13 @@ for (def i = 1; i < 8; i++) {
 
 //Sintering oven stuff
 
-crafting.addShaped("gregtech:brick_sintering_block", item('susy:sintering_brick'), [
+RecyclingHelper.addShaped("gregtech:brick_sintering_block", item('susy:sintering_brick'), [
 		[null, ore('craftingToolHardHammer'), null],
 		[metaitem('foilSteel'), item('gregtech:metal_casing', 1), metaitem('foilSteel')],
 		[null, null, null]
 ])
 
-crafting.replaceShaped("gregtech:sintering_oven", metaitem('sintering_oven'), [
+RecyclingHelper.replaceShaped("gregtech:sintering_oven", metaitem('sintering_oven'), [
 		[motors[1], rotors[1], metaitem('wireGtQuadrupleCupronickel')],
 		[circuits[1], item('gregtech:metal_casing', 1), circuits[1]],
 		[pumps[1], metaitem('wireGtQuadrupleCupronickel'), pumps[1]]
@@ -464,7 +465,7 @@ crafting.replaceShaped("gregtech:sintering_oven", metaitem('sintering_oven'), [
 
 //Regate pyrolysis oven
 
-crafting.replaceShaped("gregtech:pyrolyse_oven", metaitem('pyrolyse_oven'), [
+RecyclingHelper.replaceShaped("gregtech:pyrolyse_oven", metaitem('pyrolyse_oven'), [
 		[pistons[1], circuits[1], metaitem('wireGtQuadrupleCupronickel')],
 		[circuits[1], hulls[1], circuits[1]],
 		[pistons[1], pumps[1], metaitem('wireGtQuadrupleCupronickel')]
@@ -473,7 +474,7 @@ crafting.replaceShaped("gregtech:pyrolyse_oven", metaitem('pyrolyse_oven'), [
 //Laser Engraver -> Electron Beam Lithographer
 
 for (i = 1; i <= 8; i++) {
-	crafting.replaceShaped("gregtech:gregtech.machine.laser_engraver." + Globals.voltageTiers[i], metaitem('laser_engraver.' + Globals.voltageTiers[i]), [
+	RecyclingHelper.replaceShaped("gregtech:gregtech.machine.laser_engraver." + Globals.voltageTiers[i], metaitem('laser_engraver.' + Globals.voltageTiers[i]), [
 			[pistons[i], metaitem('wireFineTungsten'), pistons[i]],
 			[circuits[i], hulls[i], circuits[i]],
 			[tieredCables[i], circuits[i], tieredCables[i]]
@@ -486,7 +487,7 @@ for (i = 1; i <= 8; i++) {
 	crafting.remove("gregtech:gregtech.machine.fermenter." + Globals.voltageTiers[i])
 }
 
-crafting.addShaped("gregtech:fermentation_vat", metaitem('fermentation_vat'), [
+RecyclingHelper.addShaped("gregtech:fermentation_vat", metaitem('fermentation_vat'), [
 		[tieredCables[1], pumps[1], tieredCables[1]],
 		[ore('blockGlass'), hulls[1], ore('blockGlass')],
 		[tieredCables[1], circuits[1], tieredCables[1]]
@@ -495,7 +496,7 @@ crafting.addShaped("gregtech:fermentation_vat", metaitem('fermentation_vat'), [
 //UV Light Box
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:uv_light_box." + Globals.voltageTiers[i], metaitem('uv_light_box.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:uv_light_box." + Globals.voltageTiers[i], metaitem('uv_light_box.' + Globals.voltageTiers[i]), [
 			[tieredCables[i], metaitem('carbon_arc_lamp'), tieredCables[i]],
 			[circuits[i], hulls[i], circuits[i]],
 			[tieredPlates[i], tieredPlates[i], tieredPlates[i]]
@@ -505,7 +506,7 @@ for (i = 1; i <= 8; i++) {
 //Ion Implanter
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:ion_implanter." + Globals.voltageTiers[i], metaitem('ion_implanter.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:ion_implanter." + Globals.voltageTiers[i], metaitem('ion_implanter.' + Globals.voltageTiers[i]), [
 			[circuits[i], tieredGlass[i], circuits[i]],
 			[tieredMagnets[i], hulls[i], tieredMagnets[i]],
 			[tieredCables[i], tieredSprings[i], tieredCables[i]]
@@ -514,7 +515,7 @@ for (i = 1; i <= 8; i++) {
 
 // Pressure Swing Adsorber
 
-crafting.addShaped("gregtech:pressure_swing_adsorber", metaitem('pressure_swing_adsorber'), [
+RecyclingHelper.addShaped("gregtech:pressure_swing_adsorber", metaitem('pressure_swing_adsorber'), [
 		[metaitem('pipeLargeFluidAluminium'), motors[2], metaitem('pipeLargeFluidAluminium')],
 		[pumps[2], metaitem('hull.mv'), pumps[2]],
 		[circuits[2], metaitem('pipeLargeFluidAluminium'), circuits[2]]
@@ -522,37 +523,37 @@ crafting.addShaped("gregtech:pressure_swing_adsorber", metaitem('pressure_swing_
 
 //Turbine Recipes
 
-crafting.addShaped("alternator_coil", item('susy:alternator_coil'), [
+RecyclingHelper.addShaped("alternator_coil", item('susy:alternator_coil'), [
 		[ore('craftingToolHardHammer'), metaitem('electric.motor.lv'), ore('craftingToolScrewdriver')],
 		[metaitem('electric.motor.lv'), ore('plateSteel'),             metaitem('electric.motor.lv')],
 		[ore('circuitLv'),              metaitem('cableGtSingleTin'),  ore('circuitLv')]
 ])
 
-crafting.addShaped("steel_turbine_rotor", item('susy:turbine_rotor'), [
+RecyclingHelper.addShaped("steel_turbine_rotor", item('susy:turbine_rotor'), [
 		[ore('plateSteel'),             ore('screwSteel'),     ore('plateSteel')],
 		[ore('craftingToolHardHammer'), ore('stickLongSteel'), ore('craftingToolScrewdriver')],
 		[ore('plateSteel'),             ore('rotorSteel'),     ore('plateSteel')]
 ])
 
-crafting.addShaped("steel_turbine_controller", metaitem('basic_steam_turbine'), [
+RecyclingHelper.addShaped("steel_turbine_controller", metaitem('basic_steam_turbine'), [
 		[ore('plateSteel'),            metaitem('cableGtSingleTin'),       ore('plateSteel')],
 		[ore('circuitLv'),             metaitem('hull.lv'), ore('circuitLv')],
 		[metaitem('cableGtSingleTin'), ore('circuitLv'),                   metaitem('cableGtSingleTin')]
 ])
 
-crafting.replaceShaped("gregtech:casing_steel_turbine_casing", item('gregtech:turbine_casing', 5) * 4, [
+RecyclingHelper.replaceShaped("gregtech:casing_steel_turbine_casing", item('gregtech:turbine_casing', 5) * 4, [
 		[metaitem('plateSteel'), ore('craftingToolHardHammer'), metaitem('plateSteel')],
 		[metaitem('stickLongSteel'), item('gregtech:stone_smooth', 4), metaitem('stickLongSteel')],
 		[metaitem('plateSteel'), ore('craftingToolWrench'), metaitem('plateSteel')]
 ])
 
-crafting.addShaped("gas_turbine_controller", metaitem('basic_gas_turbine'), [
+RecyclingHelper.addShaped("gas_turbine_controller", metaitem('basic_gas_turbine'), [
 		[ore('plateSteel'),               metaitem('cableGtSingleCopper'),    ore('plateSteel')],
 		[ore('circuitMv'),                metaitem('hull.mv'),                ore('circuitMv')],
 		[metaitem('cableGtSingleCopper'), ore('circuitMv'),                   metaitem('cableGtSingleCopper')]
 ])
 
-crafting.addShaped("silicon_carbide_casing", item('susy:susy_multiblock_casing') * 2, [
+RecyclingHelper.addShaped("silicon_carbide_casing", item('susy:susy_multiblock_casing') * 2, [
 		[metaitem('plateSiliconCarbide'), ore('craftingToolHardHammer'), metaitem('plateSiliconCarbide')],
 		[metaitem('plateSiliconCarbide'), item('gregtech:metal_casing', 5), metaitem('plateSiliconCarbide')],
 		[metaitem('plateSiliconCarbide'), ore('craftingToolWrench'), metaitem('plateSiliconCarbide')]
@@ -644,91 +645,91 @@ recipemap('assembler').recipeBuilder()
 		.duration(200)
 		.buildAndRegister()
 
-crafting.addShaped("gregtech:ore_sorter", metaitem('ore_sorter'), [
+RecyclingHelper.addShaped("gregtech:ore_sorter", metaitem('ore_sorter'), [
 		[robotArms[1], circuits[2], robotArms[1]],
 		[pumps[1], hulls[1], pumps[1]],
 		[robotArms[1], circuits[2], robotArms[1]]
 ]);
 
-crafting.addShaped("gregtech:primitive_mud_pump", metaitem('primitive_mud_pump'), [
+RecyclingHelper.addShaped("gregtech:primitive_mud_pump", metaitem('primitive_mud_pump'), [
 		[metaitem('ringBronze'), metaitem('pipeNormalFluidTreatedWood'), metaitem('screwBronze')],
 		[metaitem('rotorBronze'), item('gregtech:steam_casing'), ore('craftingToolScrewdriver')],
 		[item('minecraft:stone_slab', 4), metaitem('pipeLargeFluidWood'), item('minecraft:stone_slab', 4)]
 ]);
 
-crafting.addShaped("gregtech:railroad_engineering_station", metaitem('railroad_engineering_station'), [
+RecyclingHelper.addShaped("gregtech:railroad_engineering_station", metaitem('railroad_engineering_station'), [
 		[robotArms[1], null, robotArms[1]],
 		[conveyors[1], hulls[1], conveyors[1]],
 		[metaitem('plateSteel'), circuits[1], metaitem('plateSteel')]
 ]);
 
-crafting.addShaped("gregtech:condenser", metaitem('condenser'), [
+RecyclingHelper.addShaped("gregtech:condenser", metaitem('condenser'), [
 		[null, metaitem('electric.pump.lv'), null],
 		[metaitem('frameSteel'), item('gregtech:boiler_casing', 1), metaitem('frameSteel')],
 		[null, metaitem('electric.pump.lv'), null]
 ]);
 
-crafting.addShaped("gregtech:heat_exchanger", metaitem('heat_exchanger'), [
+RecyclingHelper.addShaped("gregtech:heat_exchanger", metaitem('heat_exchanger'), [
 		[null, metaitem('frameSteel'), null],
 		[metaitem('electric.pump.lv'), item('gregtech:boiler_casing', 1), metaitem('electric.pump.lv')],
 		[null, metaitem('frameSteel'), null]
 ]);
 
-crafting.addShaped("gregtech:mining_drill", metaitem('mining_drill'), [
+RecyclingHelper.addShaped("gregtech:mining_drill", metaitem('mining_drill'), [
 		[circuits[1], motors[1], circuits[1]],
 		[conveyors[1], hulls[1], conveyors[1]],
 		[tieredCables[1], motors[1], tieredCables[1]]
 ]);
 
-crafting.replaceShaped("gregtech:casing_grate_casing", item('gregtech:multiblock_casing', 2) * 2, [
+RecyclingHelper.replaceShaped("gregtech:casing_grate_casing", item('gregtech:multiblock_casing', 2) * 2, [
 		[item('minecraft:iron_bars'), metaitem('rotorSteel'), item('minecraft:iron_bars')],
 		[item('minecraft:iron_bars'), metaitem('frameSteel'), item('minecraft:iron_bars')],
 		[item('minecraft:iron_bars'), metaitem('electric.motor.lv'), item('minecraft:iron_bars')]
 ])
 
-crafting.addShaped("gregtech:steel_drill_head", item('susy:drill_head'), [
+RecyclingHelper.addShaped("gregtech:steel_drill_head", item('susy:drill_head'), [
 		[pumps[1], conveyors[1], pumps[1]],
 		[metaitem('component.grinder.diamond'), item('gregtech:metal_casing', 4), metaitem('component.grinder.diamond')],
 		[null, metaitem('component.grinder.diamond'), null]
 ]);
 
-crafting.addShaped("gregtech:heat_radiator", metaitem('heat_radiator'), [
+RecyclingHelper.addShaped("gregtech:heat_radiator", metaitem('heat_radiator'), [
 		[metaitem('frameSteel'), metaitem('pipeLargeFluidSteel'), metaitem('frameSteel')],
 		[metaitem('electric.pump.lv'), hulls[1], metaitem('electric.pump.lv')],
 		[metaitem('frameSteel'), metaitem('pipeLargeFluidSteel'), metaitem('frameSteel')]
 ]);
 
-crafting.addShaped("gregtech:large_weapons_factory", metaitem('large_weapons_factory'), [
+RecyclingHelper.addShaped("gregtech:large_weapons_factory", metaitem('large_weapons_factory'), [
 		[sensors[1], robotArms[1], emitters[1]],
 		[conveyors[1], hulls[1], conveyors[1]],
 		[circuits[1], robotArms[1], circuits[1]]
 ]);
 
-crafting.addShaped("gregtech:gravity_separator", metaitem('gravity_separator'), [
+RecyclingHelper.addShaped("gregtech:gravity_separator", metaitem('gravity_separator'), [
 		[metaitem('component.grinder.diamond'), circuits[2], metaitem('component.grinder.diamond')],
 		[conveyors[2], hulls[2], conveyors[2]],
 		[circuits[2], tieredCables[2], circuits[2]]
 ]);
 
-crafting.addShaped("gregtech:reaction_furnace", metaitem('reaction_furnace'), [
+RecyclingHelper.addShaped("gregtech:reaction_furnace", metaitem('reaction_furnace'), [
 		[tieredQuadCables[2], tieredSprings[2], tieredQuadCables[2]],
 		[circuits[2], hulls[2], circuits[2]],
 		[tieredPlates[2], tieredPlates[2], tieredPlates[2]]
 ]);
 
-crafting.addShaped("gregtech:advanced_arc_furnace", metaitem('advanced_arc_furnace'), [
+RecyclingHelper.addShaped("gregtech:advanced_arc_furnace", metaitem('advanced_arc_furnace'), [
 		[metaitem('cableGtHexTin'), item('susy:electrode_assembly'), metaitem('cableGtHexTin')],
 		[circuits[1], hulls[1], circuits[1]],
 		[tieredPlates[1], tieredPlates[1], tieredPlates[1]]
 ]);
 
-crafting.addShaped("gregtech:electrode_assembly", item('susy:electrode_assembly'), [
+RecyclingHelper.addShaped("gregtech:electrode_assembly", item('susy:electrode_assembly'), [
 		[metaitem('plateSteel'), metaitem('cableGtSingleCopper'), metaitem('plateSteel')],
 		[metaitem('graphite_electrode'), metaitem('frameSteel'), metaitem('graphite_electrode')],
 		[metaitem('plateSteel'), metaitem('cableGtSingleCopper'), metaitem('plateSteel')]
 ]);
 
-crafting.addShaped("gregtech:evaporation_pool", metaitem('evaporation_pool'), [
+RecyclingHelper.addShaped("gregtech:evaporation_pool", metaitem('evaporation_pool'), [
 		[item('gregtech:stone_smooth', 4), metaitem('pipeHugeFluidAluminium'), item('gregtech:stone_smooth', 4)],
 		[pumps[2], hulls[2], pumps[2]],
 		[item('gregtech:stone_smooth', 4), metaitem('pipeHugeFluidAluminium'), item('gregtech:stone_smooth', 4)]
@@ -740,97 +741,97 @@ crafting.addShaped("gregtech:evaporation_bed", item('susy:evaporation_bed') * 8,
 		[item('minecraft:sand'), item('minecraft:dirt'), item('minecraft:sand')]
 		]);
 
-crafting.addShaped("gregtech:clarifier", metaitem('clarifier'), [
+RecyclingHelper.addShaped("gregtech:clarifier", metaitem('clarifier'), [
 		[tieredCables[2], metaitem('rotorSteel'), tieredCables[2]],
 		[pumps[2], hulls[2], pumps[2]],
 		[circuits[2], motors[2], circuits[2]]
 ]);
 
-crafting.addShaped("gregtech:clarifier_vat", item('susy:multiblock_tank') * 9, [
+RecyclingHelper.addShaped("gregtech:clarifier_vat", item('susy:multiblock_tank') * 9, [
 		[null, null, null],
 		[metaitem('plateSteel'), item('minecraft:cauldron'), metaitem('plateSteel')],
 		[metaitem('pipeSmallFluidSteel'), metaitem('pipeSmallFluidSteel'), metaitem('pipeSmallFluidSteel')]
 ]);
 
-crafting.addShaped("gregtech:multi_stage_flash_distillater", metaitem('multi_stage_flash_distiller'), [
+RecyclingHelper.addShaped("gregtech:multi_stage_flash_distillater", metaitem('multi_stage_flash_distiller'), [
 		[metaitem('plateStainlessSteel'), tieredCables[3], metaitem('plateStainlessSteel')],
 		[pumps[3], hulls[3], pumps[3]],
 		[circuits[3], tieredSprings[3], circuits[3]]
 ]);
 
-crafting.addShaped("gregtech:smoke_stack", metaitem('smoke_stack'), [
+RecyclingHelper.addShaped("gregtech:smoke_stack", metaitem('smoke_stack'), [
 		[null, metaitem('rotorSteel'), null],
 		[metaitem('pipeSmallFluidSteel'), hulls[1], metaitem('pipeSmallFluidSteel')],
 		[null, metaitem('rotorSteel'), null],
 ]);
 
-crafting.addShaped("gregtech:flare_stack", metaitem('flare_stack'), [
+RecyclingHelper.addShaped("gregtech:flare_stack", metaitem('flare_stack'), [
 		[null, metaitem('rotorSteel'), null],
 		[metaitem('stickSteel'), hulls[1], metaitem('stickSteel')],
 		[null, metaitem('rotorSteel'), null],
 ]);
 
-crafting.addShaped("gregtech:froth_flotation_tank", metaitem('froth_flotation_tank'), [
+RecyclingHelper.addShaped("gregtech:froth_flotation_tank", metaitem('froth_flotation_tank'), [
 		[tieredCables[3], metaitem('rotorStainlessSteel'), tieredCables[3]],
 		[pumps[3], hulls[3], pumps[3]],
 		[circuits[3], motors[3], circuits[3]]
 ]);
 
-crafting.addShaped("gregtech:froth_flotation_vat", item('susy:multiblock_tank', 1) * 4, [
+RecyclingHelper.addShaped("gregtech:froth_flotation_vat", item('susy:multiblock_tank', 1) * 4, [
 		[null, null, null],
 		[metaitem('plateStainlessSteel'), item('minecraft:cauldron'), metaitem('plateStainlessSteel')],
 		[metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel')]
 ]);
 
-crafting.addShaped("gregtech:vacuum_distillation_tower", metaitem('vacuum_distillation_tower'), [
+RecyclingHelper.addShaped("gregtech:vacuum_distillation_tower", metaitem('vacuum_distillation_tower'), [
 		[metaitem('rotorSteel'), circuits[2], metaitem('rotorSteel')],
 		[pumps[2], metaitem('hull.mv'), pumps[2]],
 		[metaitem('pipeHugeFluidSteel'), circuits[2], metaitem('pipeHugeFluidSteel')]
 ])
 
-crafting.replaceShaped("gregtech:vacuum_freezer", metaitem('vacuum_freezer'), [
+RecyclingHelper.replaceShaped("gregtech:vacuum_freezer", metaitem('vacuum_freezer'), [
 		[pumps[3], pumps[3], pumps[3]],
 		[circuits[3], item('gregtech:metal_casing', 3), circuits[3]],
 		[metaitem('cableGtSingleGold'), circuits[3], metaitem('cableGtSingleGold')]
 ])
 
-crafting.addShaped("gregtech:cooling_unit", metaitem('cooling_unit'), [
+RecyclingHelper.addShaped("gregtech:cooling_unit", metaitem('cooling_unit'), [
 		[metaitem('rotorStainlessSteel'), metaitem('rotorStainlessSteel'), metaitem('rotorStainlessSteel')],
 		[motors[3], metaitem('hull.hv'), motors[3]],
 		[pumps[3], circuits[3], pumps[3]]
 ])
 
-crafting.addShaped("gregtech:quencher", metaitem('quencher'), [
+RecyclingHelper.addShaped("gregtech:quencher", metaitem('quencher'), [
 		[pumps[3], metaitem('robot.arm.hv'), pumps[3]],
 		[circuits[3], item('gregtech:metal_casing', 5), circuits[3]],
 		[metaitem('pipeLargeFluidStainlessSteel'), circuits[3], metaitem('pipeLargeFluidStainlessSteel')]
 ])
 
-crafting.addShaped("gregtech:dumper", metaitem('dumper'), [
+RecyclingHelper.addShaped("gregtech:dumper", metaitem('dumper'), [
 		[metaitem('plateSteel'), metaitem('plateSteel'), metaitem('plateSteel')],
 		[metaitem('electric.pump.lv'), metaitem('hull.lv'), metaitem('pipeLargeFluidSteel')],
 		[metaitem('plateSteel'), metaitem('plateSteel'), metaitem('plateSteel')]
 ])
 
-crafting.addShaped("gregtech:ocean_pumper", metaitem('ocean_pumper'), [
+RecyclingHelper.addShaped("gregtech:ocean_pumper", metaitem('ocean_pumper'), [
 		[metaitem('stickLongAluminium'), metaitem('electric.pump.mv'), metaitem('stickLongAluminium')],
 		[ore('circuitMv'), metaitem('hull.mv'), ore('circuitMv')],
 		[metaitem('cableGtSingleCopper'), metaitem('electric.pump.mv'), metaitem('cableGtSingleCopper')]
 ])
 
-crafting.addShaped("gregtech:coking_tower", metaitem('coking_tower'), [
+RecyclingHelper.addShaped("gregtech:coking_tower", metaitem('coking_tower'), [
 		[metaitem('pipeHugeFluidSteel'), pumps[3], metaitem('pipeHugeFluidSteel')],
 		[circuits[3], hulls[3], circuits[3]],
 		[metaitem('pipeHugeFluidSteel'), pumps[3], metaitem('pipeHugeFluidSteel')]
 ]);
 
-crafting.addShaped("gregtech:rotary_kiln", metaitem('rotary_kiln'), [
+RecyclingHelper.addShaped("gregtech:rotary_kiln", metaitem('rotary_kiln'), [
 		[circuits[2], null, tieredCables[2]],
 		[metaitem('pipeHugeFluidSteel'), hulls[2], metaitem('pipeHugeFluidSteel')],
 		[circuits[2], motors[2], tieredCables[2]]
 ]);
 
-crafting.addShaped("gregtech:high_temperature_distillation_tower", metaitem('high_temperature_distillation_tower'), [
+RecyclingHelper.addShaped("gregtech:high_temperature_distillation_tower", metaitem('high_temperature_distillation_tower'), [
 		[circuits[3], item('gregtech:wire_coil'), circuits[3]],
 		[pumps[3], hulls[3], pumps[3]],
 		[circuits[3], item('gregtech:wire_coil'), circuits[3]]
@@ -839,7 +840,7 @@ crafting.addShaped("gregtech:high_temperature_distillation_tower", metaitem('hig
 //ION EXCHANGE COLUMN
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:ion_exchange_column." + Globals.voltageTiers[i], metaitem('ion_exchange_column.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:ion_exchange_column." + Globals.voltageTiers[i], metaitem('ion_exchange_column.' + Globals.voltageTiers[i]), [
 			[null, pumps[i], null],
 			[tieredGlass[i], tieredPipes[i], tieredGlass[i]],
 			[circuits[i], hulls[i], circuits[i]]
@@ -849,7 +850,7 @@ for (i = 1; i <= 8; i++) {
 // CVD
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:cvd." + Globals.voltageTiers[i], metaitem('cvd.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:cvd." + Globals.voltageTiers[i], metaitem('cvd.' + Globals.voltageTiers[i]), [
 			[pumps[i], tieredGlass[i], tieredGlass[i]],
 			[hulls[i], tieredSprings[i], tieredPipes[i]],
 			[circuits[i], tieredCables[i], tieredCables[i]]
@@ -859,7 +860,7 @@ for (i = 1; i <= 8; i++) {
 // Zone Refiner
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:zone_refiner." + Globals.voltageTiers[i], metaitem('zone_refiner.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:zone_refiner." + Globals.voltageTiers[i], metaitem('zone_refiner.' + Globals.voltageTiers[i]), [
 			[tieredSprings[i], tieredPipes[i], tieredSprings[i]],
 			[tieredQuadCables[i], hulls[i], tieredQuadCables[i]],
 			[circuits[i], conveyors[i], circuits[i]]
@@ -869,7 +870,7 @@ for (i = 1; i <= 8; i++) {
 // Tube Furnace
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:tube_furnace." + Globals.voltageTiers[i], metaitem('tube_furnace.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:tube_furnace." + Globals.voltageTiers[i], metaitem('tube_furnace.' + Globals.voltageTiers[i]), [
 			[circuits[i], tieredGlass[i], tieredGlass[i]],
 			[hulls[i], tieredSprings[i], tieredPipes[i]],
 			[tieredCables[i], conveyors[i], tieredCables[i]]
@@ -879,7 +880,7 @@ for (i = 1; i <= 8; i++) {
 // Polishing Machine
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:polishing_machine." + Globals.voltageTiers[i], metaitem('polishing_machine.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:polishing_machine." + Globals.voltageTiers[i], metaitem('polishing_machine.' + Globals.voltageTiers[i]), [
 			[robotArms[i], circuits[i], pumps[i]],
 			[tieredGlass[i], hulls[i], tieredGlass[i]],
 			[tieredCables[i], motors[i], tieredCables[i]]
@@ -889,7 +890,7 @@ for (i = 1; i <= 8; i++) {
 // Textile Spinner
 
 for (i = 1; i <= 8; i++) {
-	crafting.addShaped("gregtech:textile_spinner." + Globals.voltageTiers[i], metaitem('textile_spinner.'  + Globals.voltageTiers[i]), [
+	RecyclingHelper.addShaped("gregtech:textile_spinner." + Globals.voltageTiers[i], metaitem('textile_spinner.' + Globals.voltageTiers[i]), [
 			[circuits[i], tieredCables[i], circuits[i]],
 			[pumps[i], hulls[i], motors[i]],
 			[tieredCables[i], motors[i], motors[i]]
@@ -898,7 +899,7 @@ for (i = 1; i <= 8; i++) {
 
 // Bath Condenser
 
-crafting.addShaped("gregtech:bath_condenser", metaitem('bath_condenser'), [
+RecyclingHelper.addShaped("gregtech:bath_condenser", metaitem('bath_condenser'), [
 	[metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel')],
 	[metaitem('pipeSmallFluidStainlessSteel'), metaitem('hull.hv'), metaitem('pipeSmallFluidStainlessSteel')],
 	[metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel'), metaitem('pipeSmallFluidStainlessSteel')]
@@ -906,7 +907,7 @@ crafting.addShaped("gregtech:bath_condenser", metaitem('bath_condenser'), [
 
 // Phase Separator
 
-crafting.addShaped("gregtech:phase_separator", metaitem('phase_separator'), [
+RecyclingHelper.addShaped("gregtech:phase_separator", metaitem('phase_separator'), [
 	[metaitem('frameSteel'), metaitem('drum.steel'), metaitem('pipeSmallFluidSteel')],
 	[metaitem('pipeSmallFluidSteel'), metaitem('hull.lv'), metaitem('pipeSmallFluidSteel')]
 ])

--- a/groovy/postInit/mod/Molds.groovy
+++ b/groovy/postInit/mod/Molds.groovy
@@ -1,3 +1,5 @@
+import globals.RecyclingHelper
+
 def FORMINGPRESS = recipemap('forming_press')
 
 //ROD MOLD
@@ -5,6 +7,10 @@ crafting.addShaped("mold_rod", metaitem('shape.mold.rod'), [
     [metaitem('shape.empty'), item('gregtech:hammer'), null],
     [null, null, null],
     [null, null, null]
+])
+
+RecyclingHelper.handleRecycling(metaitem('shape.mold.rod'), [
+		metaitem('shape.empty')
 ])
 
 FORMINGPRESS.recipeBuilder()
@@ -22,10 +28,52 @@ crafting.addShaped("mold_crucible", metaitem('shape.mold.crucible'), [
     [null, null, item('gregtech:hammer')]
 ])
 
+RecyclingHelper.handleRecycling(metaitem('shape.mold.crucible'), [
+		metaitem('shape.empty')
+])
+
 FORMINGPRESS.recipeBuilder()
 	.inputs(metaitem('shape.empty'))
 	.notConsumable(metaitem('shape.mold.crucible'))
     .outputs(metaitem('shape.mold.crucible'))
 	.duration(120)
 	.EUt(22)
-	.buildAndRegister()	
+		.buildAndRegister()
+
+// LONG ROD MOLD
+crafting.addShaped("mold_long_rod", metaitem('shape.mold.long_rod'), [
+		[metaitem('shape.empty'), null, null],
+		[item('gregtech:hammer'), null, null],
+		[null, null, null]
+])
+
+RecyclingHelper.handleRecycling(metaitem('shape.mold.long_rod'), [
+		metaitem('shape.empty')
+])
+
+FORMINGPRESS.recipeBuilder()
+		.inputs(metaitem('shape.empty'))
+		.notConsumable(metaitem('shape.mold.long_rod'))
+		.outputs(metaitem('shape.mold.long_rod'))
+		.duration(120)
+		.EUt(22)
+		.buildAndRegister()
+
+// RING MOLD
+crafting.addShaped("mold_ring", metaitem('shape.mold.ring'), [
+		[metaitem('shape.empty'), null, null],
+		[null, item('gregtech:hammer'), null],
+		[null, null, null]
+])
+
+RecyclingHelper.handleRecycling(metaitem('shape.mold.ring'), [
+		metaitem('shape.empty')
+])
+
+FORMINGPRESS.recipeBuilder()
+		.inputs(metaitem('shape.empty'))
+		.notConsumable(metaitem('shape.mold.ring'))
+		.outputs(metaitem('shape.mold.ring'))
+		.duration(120)
+		.EUt(22)
+		.buildAndRegister()

--- a/groovy/postInit/mod/SusyCore.groovy
+++ b/groovy/postInit/mod/SusyCore.groovy
@@ -1,4 +1,5 @@
 import globals.Globals
+import globals.RecyclingHelper
 
 crafting.addShaped("susy:basic_structural_casing", item('susy:susy_multiblock_casing', 3) * 6, [
     [ore('screwWroughtIron'), ore('plateWroughtIron'), ore('craftingToolHardHammer')],
@@ -20,6 +21,8 @@ mods.gregtech.assembler.recipeBuilder()
     .EUt(Globals.voltAmps[1])
     .buildAndRegister()
 
+RecyclingHelper.handleRecycling(item('susy:susy_multiblock_casing', 3) * 3, [ore('plateWroughtIron') * 2])
+
 mods.gregtech.assembler.recipeBuilder()
     .inputs(ore('plateSteel') * 2)
     .inputs(ore('pipeTinyFluidCopper') * 2)
@@ -28,6 +31,8 @@ mods.gregtech.assembler.recipeBuilder()
     .duration(240)
     .EUt(Globals.voltAmps[1])
     .buildAndRegister()
+
+RecyclingHelper.handleRecycling(item('susy:serpentine') * 3, [item('gregtech:fluid_pipe_tiny', 25), ore('plateSteel')])
 
 mods.gregtech.assembler.recipeBuilder()
     .circuitMeta(10)
@@ -40,6 +45,10 @@ mods.gregtech.assembler.recipeBuilder()
     .EUt(Globals.voltAmps[1])
     .buildAndRegister()
 
+RecyclingHelper.handleRecycling(item('susy:separator_rotor') * 5,
+		[metaitem('electric.motor.hv') * 2, ore('gearStainlessSteel') * 4, ore('rotorStainlessSteel') * 16, ore('plateStainlessSteel') * 16]
+)
+
 mods.gregtech.assembler.recipeBuilder()
     .circuitMeta(9)
     .inputs(ore('plateStainlessSteel') * 9)
@@ -47,6 +56,8 @@ mods.gregtech.assembler.recipeBuilder()
     .duration(240)
     .EUt(Globals.voltAmps[3])
     .buildAndRegister()
+
+RecyclingHelper.handleRecycling(item('susy:susy_multiblock_casing', 2), [ore('plateStainlessSteel') * 9])
 
 mods.gregtech.assembler.recipeBuilder()
     .circuitMeta(11)
@@ -56,8 +67,10 @@ mods.gregtech.assembler.recipeBuilder()
     .duration(240)
     .EUt(Globals.voltAmps[3])
     .buildAndRegister()
-    
-crafting.addShaped("susy:air_vent_w", item('susy:meta_item', 4), [
+
+RecyclingHelper.handleRecycling(item('susy:susy_multiblock_casing', 1), [ore('plateStainlessSteel') * 4, ore('frameGtStainlessSteel')])
+
+RecyclingHelper.addShaped("susy:air_vent_w", item('susy:meta_item', 4), [
 	[ore('craftingToolHardHammer'),ore('stickWroughtIron'),ore('craftingToolScrewdriver')],
 	[ore('plateWroughtIron'),ore('stickWroughtIron'),ore('plateWroughtIron')],
 	[ore('screwWroughtIron'),ore('stickWroughtIron'),ore('screwWroughtIron')]
@@ -88,6 +101,7 @@ mods.gregtech.assembler.recipeBuilder()
     .duration(200)
     .EUt(Globals.voltAmps[1])
     .buildAndRegister()
+
 //Deposit stuff
 // Crushed Sulfur Ore * 1
 mods.gregtech.forge_hammer.removeByInput(16, [item('gregtech:ore_sulfur_0')], null)


### PR DESCRIPTION
## What
This PR:
- adds `RecyclingHelper.groovy` to help handling recycling. [See below on how to use it]
- ports most of machines recipes to use new method, allow them to get recycled. (fixes #838)
- removed some recipes to ensure recycling not becoming a fisson or fusion reactor :trollface:, including:
  - PBF
  - Coke oven
  - LP steam macerator
  - maybe more that I fogor
- adds recipes for susy molders (long rod, ring)
- allows inter-converting home blocks using a chisel

## How to use
- mostly quite simple, just replace the `crafting` in `crafting.replace(...)` or so into `RecyclingHelper` (don't forget to import that class), this is appliable for `addShaped`, `addShapeless`, `replaceShaped`, `replaceShaped`, and `removeByOutput` methods.
- in the case there's no crafting recipe for an item, call `RecyclingHelper.handleRecycling()` instead. Just put items of equal value of materials in the list.
- for items that have a ore prefix, you need to handle extractor recycling yourself, GT don't care about what the recipe says in this case (recycling recipe removal should work).

## Issues
CAUTION: this might have an impact on performace, especially on launch time, should do a benchmark before actually merge this.