### PR TITLE
Stops latest.log from being overflooded 

### DIFF
--- a/config/LogFilters.conf
+++ b/config/LogFilters.conf
@@ -1,0 +1,85 @@
+# See https://github.com/coolsquid/LogFilters/blob/master/LogFilters.conf for examples
+"VintageFix" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"LoliASM" = [
+	{
+		type="regex"
+        filter=".*?"
+	}
+]
+"CustomLoadingScreen" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"industrialrenewal" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"cam72cam.immersiverailroading.registry.DefinitionManager:lambda$initModels$4:240" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"vazkii.patchouli.client.book.BookContents:loadJson:258" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"net.minecraft.client.resources.LanguageManager" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"net.minecraft.client.renderer.texture.TextureMap" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"com.personthecat.cavegenerator.CaveInit" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"com.personthecat.cavegenerator.config.PresetTester" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"com.personthecat.cavegenerator.config.PresetReader" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"org.embeddedt.vintagefix.dynamicresources.model.DynamicModelProvider" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"org.embeddedt.vintagefix.dynamicresources.model.DynamicBakedModelProvider" = [
+	{
+		type="regex"
+		filter=".*?"
+	}
+]
+"root" = [
+	{
+		type="contains"
+		filter="version check"
+	}
+]

--- a/manifest.json
+++ b/manifest.json
@@ -882,6 +882,11 @@
       "projectID": 1052470,
       "fileID": 5575232,
       "required": true
+    },
+    {
+      "projectID": 272562,
+      "fileID": 2711828,
+      "required": true
     }
   ],
   "overrides": "overrides"


### PR DESCRIPTION
## What
Add [LogFilters](https://www.curseforge.com/minecraft/mc-mods/logfilters) and a config file, filter off some unnecessary logs (mostly from vintagefix and censoredasm)

Latest.log goes from 1.55 MB to 470 kB (11677 to 3545 lines)

## Potential Compatibility Issues
Might need to check if any important info are filtered off.