### PR TITLE
Fix flint tool in QB has wrong durability

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/0/9.json
+++ b/config/betterquesting/DefaultQuests/Quests/0/9.json
@@ -19,7 +19,7 @@
             "Durability:3": 0,
             "HarvestLevel:3": 1,
             "Material:8": "gregtech:flint",
-            "MaxDurability:3": 31,
+            "MaxDurability:3": 63,
             "ToolSpeed:5": 4.0
           },
           "HideFlags:3": 2
@@ -50,7 +50,7 @@
               "Durability:3": 0,
               "HarvestLevel:3": 1,
               "Material:8": "gregtech:flint",
-              "MaxDurability:3": 95,
+              "MaxDurability:3": 127,
               "ToolSpeed:5": 2.0
             },
             "HideFlags:3": 2
@@ -68,7 +68,7 @@
               "Durability:3": 0,
               "HarvestLevel:3": 1,
               "Material:8": "gregtech:flint",
-              "MaxDurability:3": 95
+              "MaxDurability:3": 127
             },
             "HideFlags:3": 2
           }
@@ -84,7 +84,7 @@
               "AttackSpeed:5": 3.0,
               "Durability:3": 0,
               "Material:8": "gregtech:flint",
-              "MaxDurability:3": 95
+              "MaxDurability:3": 127
             },
             "HideFlags:3": 2
           }


### PR DESCRIPTION
## What
The flint tool quest (namely quest ID `9`) has the tools' durability mismatch.
This PR fixes it.

## Implementation Details
Simply changed the durability.

## Outcome
Fixes #1188.

## Additional Information
It is worthy of noting that there are currently 3 quests have the GTTools NBT tag set without `ignoreNBT` (namely 9, 12, 15).
Do we need an automatic solution to this?

## Potential Compatibility Issues
None as far as I am aware.
