### PR TITLE
Change boron trioxide input to 720L in RF boron trichloride recipe

### DIFF
--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/p_block/group13/BoronChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/p_block/group13/BoronChain.groovy
@@ -197,7 +197,7 @@ BATCH_REACTOR.recipeBuilder()
 	.buildAndRegister()
 
 REACTION_FURNACE.recipeBuilder()
-		.fluidInputs(fluid('boron_trioxide') * 1000)
+		.fluidInputs(fluid('boron_trioxide') * 720)
 		.fluidInputs(fluid('chlorine') * 6000)
 		.inputs(metaitem('dustCarbon') * 3)
 		.fluidOutputs(fluid('boron_trichloride') * 2000)


### PR DESCRIPTION
## What
Changes 1000L input to 720L (5 dusts worth) as it's a molten material


