### PR TITLE
Mod updates

### DIFF
--- a/mods/craftpresence.pw.toml
+++ b/mods/craftpresence.pw.toml
@@ -1,13 +1,13 @@
 name = "CraftPresence"
-filename = "CraftPresence-2.5.2+1.12.2-forge.jar"
+filename = "CraftPresence-2.5.3+1.12.2-forge.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "f5c7a772563ca40629904d076b7928b8ea5e6a0d"
+hash = "ff30adbacf72e6117e570abdb48a3dcdbc19752f"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5947458
+file-id = 6088811
 project-id = 297038

--- a/mods/forgelin-continuous.pw.toml
+++ b/mods/forgelin-continuous.pw.toml
@@ -1,13 +1,13 @@
 name = "Forgelin-Continuous"
-filename = "Forgelin-Continuous-2.1.0.0.jar"
+filename = "Forgelin-Continuous-2.1.10.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "5129eb62edbe41d37c56d72899a3ad42794cb6d6"
+hash = "bbd95b1d616fdb6090b0da0c96f36d2e8081b1d5"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5946402
+file-id = 6142081
 project-id = 456403

--- a/mods/gregtech-food-option.pw.toml
+++ b/mods/gregtech-food-option.pw.toml
@@ -1,13 +1,13 @@
 name = "GregTech Food Option"
-filename = "gregtechfoodoption-1.12.2-1.12.3.jar"
+filename = "gregtechfoodoption-1.12.2-1.12.4.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "fcee9e7ecc0dfdbca0cfdbff16d7705f4927472a"
+hash = "c689f101e77dcc05b7d9d41f8235c46fd4b50f19"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5994740
+file-id = 6147619
 project-id = 477021

--- a/mods/lolasm.pw.toml
+++ b/mods/lolasm.pw.toml
@@ -1,13 +1,13 @@
 name = "CensoredASM"
-filename = "censoredasm5.20.jar"
+filename = "censoredasm5.23.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "bdfaa0211280b44a18ac9751030409595d3b7750"
+hash = "b510c7b6a02287accae1ba207ca3d145ffe57737"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5257348
+file-id = 6151035
 project-id = 460609

--- a/mods/mixin-booter.pw.toml
+++ b/mods/mixin-booter.pw.toml
@@ -1,13 +1,13 @@
 name = "MixinBooter"
-filename = "!mixinbooter-10.2.jar"
+filename = "!mixinbooter-10.4.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "69f649f03f1b8706ec96945ed2722c653da07c33"
+hash = "ee287cc1cee8c602eb6fefe0190ed3d0859ae99a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5906634
+file-id = 6118480
 project-id = 419286

--- a/mods/nutrition-unofficial-extended-life.pw.toml
+++ b/mods/nutrition-unofficial-extended-life.pw.toml
@@ -1,13 +1,13 @@
 name = "Nutrition Unofficial Extended Life"
-filename = "Nutrition-UEL-4.15.0.jar"
+filename = "Nutrition-UEL-4.16.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "ceced5d82b158370c8419b7ad0e394eab538bf17"
+hash = "eb353bb4aea78b1ce030ad5bf4fb15f830b3701d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6082761
+file-id = 6095757
 project-id = 964516

--- a/mods/sound-physics-remixin.pw.toml
+++ b/mods/sound-physics-remixin.pw.toml
@@ -1,13 +1,13 @@
 name = "籁/Sound Physics Remixin"
-filename = "soundphysics-1.1.9.jar"
+filename = "soundphysics-1.1.10.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "6faed82598ea87fa736fa5f11b654d74ac0ff45a"
+hash = "044317b9efc9ba409fa9b404a284be6266c0412a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6067791
+file-id = 6136553
 project-id = 951159

--- a/mods/unilib.pw.toml
+++ b/mods/unilib.pw.toml
@@ -1,13 +1,13 @@
 name = "UniLib"
-filename = "UniLib-1.0.4+1.12.2-forge.jar"
+filename = "UniLib-1.0.5+1.12.2-forge.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "920924267ca9503bee098f4d95745f2f7ed1b2c8"
+hash = "c56cdf1c44e5290d5c0816eb2844bde6613d9ce6"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5946214
+file-id = 6088140
 project-id = 1056812

--- a/mods/xp-orb-clump.pw.toml
+++ b/mods/xp-orb-clump.pw.toml
@@ -1,13 +1,13 @@
 name = "Fixeroo"
-filename = "Fixeroo-2.3.3-hotfix.1.jar"
+filename = "Fixeroo-2.3.4.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "4ab101dca261913008ded0836f26544523bb0104"
+hash = "2dec71f06d9c718cdd04cd3a7846b90e66da06e1"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6059919
+file-id = 6124010
 project-id = 633806


### PR DESCRIPTION
## What
mod updates, mostly just version bumps.
could wait for the next susycore update

 - Nutrition Unofficial Extended Life: 4.15.0-> 4.16.0
 - Forgelin-Continuous: 2.1.0.0 -> 2.1.10.0
 - CraftPresence: 2.5.2 -> 2.5.3
 - CensoredASM: 5.20 -> 5.23
 - GregTech Food Option: 1.12.3 -> 1.12.4
 - UniLib: 1.0.4 -> 1.0.5
 - 籁/Sound Physics Remixin: 1.1.9 -> 1.1.10
 - Fixeroo: 2.3.3-hotfix.1 -> 2.3.4
 - MixinBooter: 10.2 -> 10.4
 
should fix #1191
