### PR TITLE
fix: sent LT beds to the backrooms

### DIFF
--- a/config/littletiles.json
+++ b/config/littletiles.json
@@ -10,7 +10,7 @@
     "allowFlowingWater": true,
     "allowFlowingLava": true,
     "storagePerPixel": 1.0,
-    "enableBed": true,
+    "enableBed": false,
     "enableAnimationCollision": true,
     "enableCollisionMotion": true,
     "dyeVolume": 2.0,


### PR DESCRIPTION
fixed bug where players were able to create beds with littletiles and use them to skip the night in the early game

## What
zalgonizing the LT bed

## Implementation Details
this is a 1 line change

## Outcome
LT beds get zalgonized

## Additional Information
people can no longer skip the night without crafting the proper bed

## Potential Compatibility Issues
none
