### PR TITLE
Remove Bonus Chest

### DIFF
--- a/groovy/postInit/gameplay/LootTweaks.groovy
+++ b/groovy/postInit/gameplay/LootTweaks.groovy
@@ -1,9 +1,14 @@
 import com.cleanroommc.groovyscript.event.LootTablesLoadedEvent;
 
-def lootTables = ["minecraft:chests/simple_dungeon", "minecraft:chests/village_blacksmith", "minecraft:chests/spawn_bonus_chest", "minecraft:chests/stronghold_library"]
+def lootTables = ["minecraft:chests/simple_dungeon", "minecraft:chests/village_blacksmith", "minecraft:chests/stronghold_library"]
+def bonusChestTable = "minecraft:chests/spawn_bonus_chest"
+def bonusChestPools = ["main", "pool1", "pool2", "pool3", "sgcraft0", "sgcraft1", "sgcraft2", "sgcraft3"]
 
 event_manager.listen { LootTablesLoadedEvent event ->
     for (def lt in lootTables) {
         event.loot.getTable(lt).removePool("sgcraft0");
+    }
+    for (def pool in bonusChestPools) {
+        event.loot.getTable(bonusChestTable).removePool(pool);
     }
 }

--- a/groovy/postInit/gameplay/StartingAge.groovy
+++ b/groovy/postInit/gameplay/StartingAge.groovy
@@ -181,10 +181,6 @@ for (mat_name in GrindstoneOreList)
     def mat_cap = mat.toCamelCaseString()
     mat_cap = mat_cap.substring(0, 1).toUpperCase() + mat_cap.substring(1);
 
-    log.info(mat)
-    log.info(mat_cap)
-    log.info(mat.oreMultiplier())
-
     builder.withInput(item("gregtech:ore_" + mat + "_0") * 2)
     builder.withOutput(metaitem('crushed' + mat_cap) * (int)(mat.oreMultiplier() * 3))
     builder.withTurns(5)


### PR DESCRIPTION
## What
Completely remove all current pools from bonus chest. (Fixes #1285)

Also there were some debug messages left in #1257. They are now removed.

## Implementation Details
Hardcode the pools since there's no documentation of how to get the whole list of certain loot.

## Outcome
Bonus chest now consists of, 1 chest block and optionally 4 torches.

## Potential Compatibility Issues
None.
