### PR TITLE
Revert CensoredASM version

### DIFF
--- a/mods/lolasm.pw.toml
+++ b/mods/lolasm.pw.toml
@@ -1,13 +1,13 @@
 name = "CensoredASM"
-filename = "censoredasm5.23.jar"
+filename = "censoredasm5.22.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b510c7b6a02287accae1ba207ca3d145ffe57737"
+hash = "9dcccb5027d2519f2d0fec3b874f96c47fa6a849"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6151035
+file-id = 6124959
 project-id = 460609


### PR DESCRIPTION
Latest version of it ignores the `onDemandAnimatedTextures=false` setting in its config.
this is due to [#3bbcfb8](https://github.com/LoliKingdom/LoliASM/commit/3bbcfb86b85cfc2fb609093ab9f9b3a4ee5e7225) just checking optifine's absense for enabling on-demand animation.

Tested and worked on my machine :trollface:.

