### PR TITLE
Urgent fix for groovy

### DIFF
--- a/groovy/classes/ChangeFlags.groovy
+++ b/groovy/classes/ChangeFlags.groovy
@@ -228,9 +228,8 @@ class ChangeFlags {
         Rutile.addFlags("generate_concentrate");
         setupSlurries(Sphalerite)
         setupSlurries(Pollucite)
-        setupSlurries(Arsenopyrite)
         Pentlandite.addFlags("generate_sifted", "generate_flotated");
-		setupSlurries(Pentlandite)
+        setupSlurries(Pentlandite)
 
         setupFluidType(PolyvinylAcetate, FluidStorageKeys.LIQUID, 385)
 


### PR DESCRIPTION
Groovy should be able to load ChangeFlags.groovy properly now
Apparently, Arsenopyrite has already been added IMPURE_SLURRY tag in material/OreMaterials.groovy