### PR TITLE
Fix some recipes still using hard coded primitive LV circuits

### DIFF
--- a/groovy/postInit/mod/RFTools.groovy
+++ b/groovy/postInit/mod/RFTools.groovy
@@ -109,55 +109,55 @@ crafting.replaceShaped('rftools:storage_module_2', item('rftools:storage_module'
 
 crafting.replaceShaped('rftools:redstone_transmitter_block', item('rftools:redstone_transmitter_block'), [
         [null, null, null],
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('emitter.lv')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('emitter.lv')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:redstone_receiver_block', item('rftools:redstone_receiver_block'), [
         [null, null, null],
-        [metaitem('sensor.lv'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('sensor.lv'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:sequencer_block', item('rftools:sequencer_block'), [
         [null, item('minecraft:redstone_torch'), null],
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:counter_block', item('rftools:counter_block'), [
         [null, item('minecraft:comparator'), null],
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:logic_block', item('rftools:logic_block'), [
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [item('minecraft:comparator'), metaitem('plateStone'), item('minecraft:comparator')],
         [metaitem('wireFineRedAlloy'), item('minecraft:comparator'), metaitem('wireFineRedAlloy')]
 ])
 
 crafting.replaceShaped('rftools:invchecker_block', item('rftools:invchecker_block'), [
         [null, null, null],
-        [item('minecraft:comparator'), metaitem('circuit.electronic'), metaitem('sensor.mv')],
+        [item('minecraft:comparator'), ore('circuitLv'), metaitem('sensor.mv')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:sensor_block', item('rftools:sensor_block'), [
         [null, null, null],
-        [item('minecraft:comparator'), metaitem('circuit.electronic'), metaitem('camera')],
+        [item('minecraft:comparator'), ore('circuitLv'), metaitem('camera')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:analog_block', item('rftools:analog_block'), [
         [null, metaitem('wireFineRedAlloy'), null],
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [null, metaitem('plateStone'), null]
 ])
 
 crafting.replaceShaped('rftools:digit_block', item('rftools:digit_block'), [
         [null, ore('paneGlass'), null],
-        [metaitem('wireFineRedAlloy'), metaitem('circuit.electronic'), metaitem('wireFineRedAlloy')],
+        [metaitem('wireFineRedAlloy'), ore('circuitLv'), metaitem('wireFineRedAlloy')],
         [null, metaitem('plateStone'), null]
 ])
 
@@ -228,9 +228,9 @@ crafting.replaceShaped('rftools:shield_template_block', item('rftools:shield_tem
 ])
 
 crafting.replaceShaped('rftools:item_filter', item('rftools:item_filter'), [
-        [metaitem('circuit.electronic'), metaitem('pipeSmallItemTin'), metaitem('item_filter')],
+        [ore('circuitLv'), metaitem('pipeSmallItemTin'), metaitem('item_filter')],
         [metaitem('pipeSmallItemTin'), metaitem('hull.lv'), metaitem('pipeSmallItemTin')],
-        [metaitem('item_filter'), metaitem('pipeSmallItemTin'), metaitem('circuit.electronic')]
+        [metaitem('item_filter'), metaitem('pipeSmallItemTin'), ore('circuitLv')]
 ])
 
 crafting.replaceShaped('rftools:filter_module', item('rftools:filter_module'), [

--- a/groovy/postInit/mod/RedstoneControl.groovy
+++ b/groovy/postInit/mod/RedstoneControl.groovy
@@ -133,7 +133,7 @@ crafting.replaceShaped('cd4017be_lib:rs_ctr/assembler', item('rs_ctr:assembler')
 
 crafting.replaceShaped('cd4017be_lib:rs_ctr/editor', item('rs_ctr:editor'), [
         [null, ore('paneGlass'), null],
-        [metaitem('circuit.electronic'), metaitem('plateSteel'), metaitem('circuit.electronic')],
+        [ore('circuitLv'), metaitem('plateSteel'), ore('circuitLv')],
         [null, metaitem('workbench'), null]
 ])
 
@@ -164,7 +164,7 @@ crafting.replaceShaped('cd4017be_lib:rs_ctr/panel', item('rs_ctr:panel'), [
 crafting.replaceShaped('cd4017be_lib:rs_ctr/slider', item('rs_ctr:slider'), [
         [null, null, null],
         [item('minecraft:redstone_torch'), metaitem('stickSteel'), item('rs_ctr:wire')],
-        [null, metaitem('circuit.electronic'), null]
+        [null, ore('circuitLv'), null]
 ])
 
 crafting.replaceShaped('cd4017be_lib:rs_ctr/seg7_0', item('rs_ctr:seg7'), [


### PR DESCRIPTION
## What
RedstoneControl and RFTools recipes were locked to using primitive LV circuits.

## Outcome
This changes all the offending recipes to use the circuitLv oredict. 


