### PR TITLE
Finish remove alloy blast smelter recipes

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1306,7 +1306,6 @@ mods.gregtech.alloy_blast_smelter.removeByInput(120, [metaitem('dustNickel'), me
 mods.gregtech.alloy_blast_smelter.removeByInput(7680, [metaitem('dustYttrium'), metaitem('dustBarium') * 2, metaitem('dustCopper') * 3, metaitem('circuit.integrated').withNbt(["Configuration": 14])], [fluid('oxygen') * 7000, fluid('argon') * 650])
 // Molten Yttrium Barium Cuprate * 1872
 mods.gregtech.alloy_blast_smelter.removeByInput(7680, [metaitem('dustYttrium'), metaitem('dustBarium') * 2, metaitem('dustCopper') * 3, metaitem('circuit.integrated').withNbt(["Configuration": 4])], [fluid('oxygen') * 7000])
-
 // Molten Mercury Barium Calcium Cuprate * 2304
 mods.gregtech.alloy_blast_smelter.removeByInput(480, [metaitem('dustBarium') * 2, metaitem('dustCalcium') * 2, metaitem('dustCopper') * 3, metaitem('circuit.integrated').withNbt(["Configuration": 5])], [fluid('mercury') * 1000, fluid('oxygen') * 8000])
 // Molten Mercury Barium Calcium Cuprate * 2304
@@ -1319,6 +1318,34 @@ mods.gregtech.alloy_blast_smelter.removeByInput(7680, [metaitem('dustIndium') * 
 mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustSamarium'), metaitem('dustIron'), metaitem('dustArsenic'), metaitem('circuit.integrated').withNbt(["Configuration": 14])], [fluid('oxygen') * 1000, fluid('helium') * 400])
 // Molten Samarium Iron Arsenic Oxide * 576
 mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustSamarium'), metaitem('dustIron'), metaitem('dustArsenic'), metaitem('circuit.integrated').withNbt(["Configuration": 4])], [fluid('oxygen') * 1000])
+// Molten Maraging Steel 300 * 3456
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 16, metaitem('dustTitanium'), metaitem('dustAluminium'), metaitem('dustNickel') * 4, metaitem('dustCobalt') * 2, metaitem('circuit.integrated').withNbt(['Configuration': 15])], [fluid('argon') * 1200 * 1200])
+// Molten Maraging Steel 300 * 3456
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 16, metaitem('dustTitanium'), metaitem('dustAluminium'), metaitem('dustNickel') * 4, metaitem('dustCobalt') * 2, metaitem('circuit.integrated').withNbt(['Configuration': 5])], null)
+// Molten Hastelloy-C276 * 4320
+mods.gregtech.alloy_blast_smelter.removeByInput(120, [metaitem('dustNickel') * 12, metaitem('dustMolybdenum') * 8, metaitem('dustChrome') * 7, metaitem('dustTungsten'), metaitem('dustCobalt'), metaitem('dustCopper'), metaitem('circuit.integrated').withNbt(['Configuration': 16])], [fluid('helium') * 3000 * 3000])
+// Molten Hastelloy-C276 * 4320
+mods.gregtech.alloy_blast_smelter.removeByInput(120, [metaitem('dustNickel') * 12, metaitem('dustMolybdenum') * 8, metaitem('dustChrome') * 7, metaitem('dustTungsten'), metaitem('dustCobalt'), metaitem('dustCopper'), metaitem('circuit.integrated').withNbt(['Configuration': 6])], null)
+// Molten Hastelloy-X * 2736
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustNickel') * 8, metaitem('dustIron') * 3, metaitem('dustTungsten') * 4, metaitem('dustMolybdenum') * 2, metaitem('dustChrome'), metaitem('dustNiobium'), metaitem('circuit.integrated').withNbt(['Configuration': 16])], [fluid('argon') * 950 * 950])
+// Molten Hastelloy-X * 2736
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustNickel') * 8, metaitem('dustIron') * 3, metaitem('dustTungsten') * 4, metaitem('dustMolybdenum') * 2, metaitem('dustChrome'), metaitem('dustNiobium'), metaitem('circuit.integrated').withNbt(['Configuration': 6])], null)
+// Molten Incoloy-MA956 * 1872
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustVanadiumSteel') * 4, metaitem('dustManganese') * 2, metaitem('dustAluminium') * 5, metaitem('dustYttrium') * 2, metaitem('circuit.integrated').withNbt(['Configuration': 14])], [fluid('helium') * 1300 * 1300])
+// Molten Incoloy-MA956 * 1872
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustVanadiumSteel') * 4, metaitem('dustManganese') * 2, metaitem('dustAluminium') * 5, metaitem('dustYttrium') * 2, metaitem('circuit.integrated').withNbt(['Configuration': 4])], null)
+// Molten Watertight Steel * 2160
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 7, metaitem('dustAluminium') * 4, metaitem('dustNickel') * 2, metaitem('dustChrome'), metaitem('dustSulfur'), metaitem('circuit.integrated').withNbt(['Configuration': 15])], [fluid('helium') * 1500 * 1500])
+// Molten Watertight Steel * 2160
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 7, metaitem('dustAluminium') * 4, metaitem('dustNickel') * 2, metaitem('dustChrome'), metaitem('dustSulfur'), metaitem('circuit.integrated').withNbt(['Configuration': 5])], null)
+// Molten Stellite-100 * 1440
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 4, metaitem('dustChrome') * 3, metaitem('dustTungsten') * 2, metaitem('dustMolybdenum'), metaitem('circuit.integrated').withNbt(['Configuration': 14])], [fluid('argon') * 500 * 500])
+// Molten Stellite-100 * 1440
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 4, metaitem('dustChrome') * 3, metaitem('dustTungsten') * 2, metaitem('dustMolybdenum'), metaitem('circuit.integrated').withNbt(['Configuration': 4])], null)
+// Molten Zeron-100 * 2304
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 10, metaitem('dustNickel') * 2, metaitem('dustTungsten') * 2, metaitem('dustNiobium'), metaitem('dustCobalt'), metaitem('circuit.integrated').withNbt(['Configuration': 15])], [fluid('helium') * 1600 * 1600])
+// Molten Zeron-100 * 2304
+mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 10, metaitem('dustNickel') * 2, metaitem('dustTungsten') * 2, metaitem('dustNiobium'), metaitem('dustCobalt'), metaitem('circuit.integrated').withNbt(['Configuration': 5])], null)
 
 // NAND Chip * 8
 mods.gregtech.circuit_assembler.removeByInput(120, [metaitem('circuit_board.good'), metaitem('plate.simple_system_on_chip'), metaitem('boltRedAlloy') * 2, metaitem('wireFineTin') * 2], [fluid('soldering_alloy') * 72])

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1346,6 +1346,10 @@ mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 4,
 mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 10, metaitem('dustNickel') * 2, metaitem('dustTungsten') * 2, metaitem('dustNiobium'), metaitem('dustCobalt'), metaitem('circuit.integrated').withNbt(['Configuration': 15])], [fluid('helium') * 1600 * 1600])
 // Molten Zeron-100 * 2304
 mods.gregtech.alloy_blast_smelter.removeByInput(1920, [metaitem('dustIron') * 10, metaitem('dustNickel') * 2, metaitem('dustTungsten') * 2, metaitem('dustNiobium'), metaitem('dustCobalt'), metaitem('circuit.integrated').withNbt(['Configuration': 5])], null)
+// Liquid HSLA Steel * 720
+mods.gregtech.alloy_blast_smelter.removeByInput(480, [metaitem('dustInvar') * 2, metaitem('dustVanadium'), metaitem('dustTitanium'), metaitem('dustMolybdenum'), metaitem('circuit.integrated').withNbt(['Configuration': 14])], [fluid('nitrogen') * 5000 * 5000])
+// Liquid HSLA Steel * 720
+mods.gregtech.alloy_blast_smelter.removeByInput(480, [metaitem('dustInvar') * 2, metaitem('dustVanadium'), metaitem('dustTitanium'), metaitem('dustMolybdenum'), metaitem('circuit.integrated').withNbt(['Configuration': 4])], null)
 
 // NAND Chip * 8
 mods.gregtech.circuit_assembler.removeByInput(120, [metaitem('circuit_board.good'), metaitem('plate.simple_system_on_chip'), metaitem('boltRedAlloy') * 2, metaitem('wireFineTin') * 2], [fluid('soldering_alloy') * 72])


### PR DESCRIPTION
## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->

@WideMann was removing superalloys in this pr #1118 but didn't remove the alloy blast smelter recipes

## Implementation Details
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->
edit GregTech.groovy

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->
Many alloy blast smelter recipes removed (with and without fluid):
- Maraging Steel 300
- Hastelloy-C276
- Hastelloy-X
- Incoloy-MA956
- Watertight Steel
- Stellite-100
- Zeron-100
- HSLA Steel

## Additional Information
<!--This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of.-->
I'm TCSlender in the susy discord if more info needed

## Potential Compatibility Issues
<!--This section is for defining possible compatibility issues. It must be used when there item/block/material/machine changes, or recipe changes.-->
Should be no compatibility issues

<!--**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**-->
