### PR TITLE
fixes: #1194

### DIFF
--- a/structures/active/Alluvial.rcbp
+++ b/structures/active/Alluvial.rcbp
@@ -12,10 +12,6 @@
     {
       "biomes": "$RIVER",
       "weight": 2.5
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Hydrothermal.rcbp
+++ b/structures/active/Hydrothermal.rcbp
@@ -15,10 +15,6 @@
     {
       "biomes": "$JUNGLE",
       "weight": 0.25
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/LaunchPadBiomes.rcbp
+++ b/structures/active/LaunchPadBiomes.rcbp
@@ -8,9 +8,6 @@
     },
     {
       "biomes": "$WASTELAND"
-    },
-    {
-      "biomes": ""
     }
   ],
   "metadata": {

--- a/structures/active/MagmaticHydrothermal.rcbp
+++ b/structures/active/MagmaticHydrothermal.rcbp
@@ -15,10 +15,6 @@
     {
       "biomes": "$LUSH",
       "weight": 0.4
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Metamorphic.rcbp
+++ b/structures/active/Metamorphic.rcbp
@@ -7,10 +7,6 @@
     {
       "biomes": "$HILLS",
       "weight": 0.4
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Orthomagmatic.rcbp
+++ b/structures/active/Orthomagmatic.rcbp
@@ -11,10 +11,6 @@
     {
       "biomes": "volcanic",
       "weight": 1.5
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {

--- a/structures/active/Sedimentary.rcbp
+++ b/structures/active/Sedimentary.rcbp
@@ -19,10 +19,6 @@
     {
       "biomes": "$MESA",
       "weight": 0.9
-    },
-    {
-      "biomes": "",
-      "weight": 0.1
     }
   ],
   "metadata": {


### PR DESCRIPTION
Ore deposits and the federation launch pads no longer spawn in the beneath or the nether. https://github.com/SymmetricDevs/Supersymmetry/issues/1194

## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->
Overworld structures no longer spawn in the beneath or the nether
This has the added benefit of making them slightly more common in the overworld in their respective biomes.


## Implementation Details
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->
Fixes: #1194

## Additional Information
<!--This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of.-->
This locks generation of ore deposits (even with commands) to their respective biomes, making testing harder

## Potential Compatibility Issues
<!--This section is for defining possible compatibility issues. It must be used when there item/block/material/machine changes, or recipe changes.-->

<!--**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**-->
