### PR TITLE
NightVision Goggles additional battery recipes

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1308,6 +1308,20 @@ crafting.replaceShaped('gregtech:lv_power_unit_lead_acid', metaitem('power_unit.
         [ore('plateSteel'), metaitem('battery.lead_acid'), ore('plateSteel')]
 ])
 
+// NightVision Goggles with other batteries
+
+crafting.addShaped('gregtech:nightvision_lithium', metaitem('nightvision_goggles').withNbt([MaxCharge: 120000L]), [
+    [ore('circuitUlv'), metaitem('screwSteel'), ore('circuitUlv')],
+    [metaitem('ringRubber'), metaitem('battery.re.lv.lithium'), metaitem('ringRubber')],
+    [metaitem('lensGlass'), ore('toolScrewdriver'), metaitem('lensGlass')]
+])
+
+crafting.addShaped('gregtech:nightvision_cadmium', metaitem('nightvision_goggles').withNbt([MaxCharge: 100000L]), [
+[ore('circuitUlv'), metaitem('screwSteel'), ore('circuitUlv')],
+    [metaitem('ringRubber'), metaitem('battery.re.lv.cadmium'), metaitem('ringRubber')],
+    [metaitem('lensGlass'), ore('toolScrewdriver'), metaitem('lensGlass')]
+])
+
 // Stone oredict stuff
 
 // Stone Dust * 1


### PR DESCRIPTION
Added crafting recipes for the night vision goggles that allows for the use of the Lithium and Cadmium battery variants. These goggles also have an altered max charge capacity that matches with the battery used in the recipe.