### PR TITLE
remove inductor dependency for MV regulator quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/3/498154717.json
+++ b/config/betterquesting/DefaultQuests/Quests/3/498154717.json
@@ -1,8 +1,7 @@
 {
   "preRequisites:11": [
     1786950658,
-    1090881854,
-    496
+    1090881854
   ],
   "properties:10": {
     "betterquesting:10": {


### PR DESCRIPTION
## What
Removes the MV regulator quests dependency on the inductor quest because it isn't used in its recipe.