### PR TITLE
Update GrS from 1.2.0-hotfix to 1.2.3

### DIFF
--- a/groovy/postInit/metallurgy/Superalloys.groovy
+++ b/groovy/postInit/metallurgy/Superalloys.groovy
@@ -1,5 +1,5 @@
 import globals.Globals
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 
 ABS = recipemap('alloy_blast_smelter')
 

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1,6 +1,5 @@
-import globals.Globals
 import globals.GroovyUtils
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 import gregtech.common.blocks.MetaBlocks
 import gregtech.common.blocks.MetaBlocks.*
 import net.minecraft.init.Blocks
@@ -290,7 +289,7 @@ for (fluid in fluid_removals) {
 //ADDITIONS
 
 //CONSUMES IRON BUCKET ONLY BECAUSE THE OUTPUT IS IN AN IRON BUCKET
-crafting.addShapeless('gregtech:salt_water_bucket', item('forge:bucketfilled').withNbt(["FluidName": "salt_water", "Amount": 1000]), [item('minecraft:water_bucket').noreturn(), metaitem('dustSalt'), metaitem('dustSalt')])
+crafting.addShapeless('gregtech:salt_water_bucket', item('forge:bucketfilled').withNbt(["FluidName": "salt_water", "Amount": 1000]), [item('minecraft:water_bucket').noReturn(), metaitem('dustSalt'), metaitem('dustSalt')])
 
 RecyclingHelper.replaceShaped('gregtech:large_steel_boiler', metaitem('large_boiler.steel'), [
     [ore('cableGtSingleCopper'), ore('circuitMv'), ore('cableGtSingleCopper')],
@@ -970,27 +969,27 @@ RecyclingHelper.handleRecycling(metaitem('drum.uhmwpe'), [metaitem('plateUltraHi
 
 // ModHandler.addShapelessNBTClearingRecipe() is not reloadable, just using these seems fine, and we indeed have tooltips.
 crafting.addShapeless("drum_nbt_lead", metaitem('drum.lead'), [
-        metaitem('drum.lead').noreturn()
+        metaitem('drum.lead').noReturn()
 ]);
 
 crafting.addShapeless("drum_nbt_brass", metaitem('drum.brass'), [
-        metaitem('drum.brass').noreturn()
+        metaitem('drum.brass').noReturn()
 ]);
 
 crafting.addShapeless("drum_nbt_pe", metaitem('drum.pe'), [
-        metaitem('drum.pe').noreturn()
+        metaitem('drum.pe').noReturn()
 ]);
 
 crafting.addShapeless("drum_nbt_pp", metaitem('drum.pp'), [
-        metaitem('drum.pp').noreturn()
+        metaitem('drum.pp').noReturn()
 ]);
 
 crafting.addShapeless("drum_nbt_ptfe", metaitem('drum.ptfe'), [
-        metaitem('drum.ptfe').noreturn()
+        metaitem('drum.ptfe').noReturn()
 ]);
 
 crafting.addShapeless("drum_nbt_uhmwpe", metaitem('drum.uhmwpe'), [
-        metaitem('drum.uhmwpe').noreturn()
+        metaitem('drum.uhmwpe').noReturn()
 ]);
 
 ASSEMBLER.recipeBuilder()

--- a/groovy/postInit/mod/GregTechFoodOption.groovy
+++ b/groovy/postInit/mod/GregTechFoodOption.groovy
@@ -1,7 +1,5 @@
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 import gregtechfoodoption.utils.GTFOUtils
-
-import static gregtechfoodoption.utils.GTFOUtils.*
 
 // MACHINE RECIPES
 

--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -1,7 +1,5 @@
 import globals.Globals
-import globals.RecyclingHelper
-
-import static gregtech.api.unification.material.Materials.*
+import postInit.utils.RecyclingHelper
 
 def name_removals = [
 	'gregtech:gregtech.machine.fisher.lv',

--- a/groovy/postInit/mod/Molds.groovy
+++ b/groovy/postInit/mod/Molds.groovy
@@ -1,4 +1,4 @@
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 
 def FORMINGPRESS = recipemap('forming_press')
 

--- a/groovy/postInit/mod/Pyrotech.groovy
+++ b/groovy/postInit/mod/Pyrotech.groovy
@@ -5,7 +5,7 @@ import com.codetaylor.mc.pyrotech.library.spi.block.IBlockIgnitableWithIgniterIt
 import com.codetaylor.mc.pyrotech.modules.tech.basic.ModuleTechBasic
 import com.codetaylor.mc.pyrotech.modules.tech.basic.block.BlockKilnPit
 import globals.Globals
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 import gregtech.api.items.metaitem.MetaItem
 import gregtech.api.items.metaitem.stats.IItemBehaviour
 import gregtech.api.util.GTUtility

--- a/groovy/postInit/mod/SusyCore.groovy
+++ b/groovy/postInit/mod/SusyCore.groovy
@@ -1,5 +1,5 @@
 import globals.Globals
-import globals.RecyclingHelper
+import postInit.utils.RecyclingHelper
 import gregtech.api.recipes.ingredients.nbtmatch.*
 
 ASSEMBLER = recipemap('assembler')

--- a/groovy/postInit/utils/RecyclingHelper.groovy
+++ b/groovy/postInit/utils/RecyclingHelper.groovy
@@ -1,4 +1,4 @@
-package globals
+package postInit.utils
 
 import com.cleanroommc.groovyscript.api.IIngredient
 import gregtech.api.recipes.RecipeMap
@@ -16,6 +16,7 @@ import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
 import java.util.stream.Collectors
 
 /**
+ * TODO: refactor this
  * An utility class that handles recycling recipes,
  * with many codes copied from CEu itself.
  * Note: This DOES NOT work with extractor,

--- a/groovy/runConfig.json
+++ b/groovy/runConfig.json
@@ -3,26 +3,14 @@
   "packId": "supersymmetry",
   "version": "1.0.0",
   "debug": false,
-  "classes": [
-    "classes/ChangeFlags.groovy",
-    "classes/ICoolant.groovy",
-    "classes/ICryoGas.groovy",
-    "classes/IFluidFuel.groovy",
-    "classes/IOreRock.groovy",
-    "classes/IQuenchingFluid.groovy",
-    "classes/IRefrigerant.groovy",
-    "classes/IWorkingFluid.groovy",
-    "classes/ISupercriticalFluid.groovy",
-    "globals/",
-    "material/"
-  ],
   "loaders": {
     "preInit": [
+      "classes/",
+      "globals/",
       "material/",
       "preInit/"
     ],
     "postInit": [
-      "globals/",
       "prePostInit/",
       "postInit/"
     ]

--- a/mods/groovyscript.pw.toml
+++ b/mods/groovyscript.pw.toml
@@ -1,13 +1,13 @@
 name = "GroovyScript"
-filename = "groovyscript-1.2.0-hotfix1.jar"
+filename = "groovyscript-1.2.3.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "0c4968eb7eabd4ed6bc60bb2276f1691fb99f7da"
+hash = "95c3b408cc47ceec15af0f5193193bde5faff8c8"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5789690
+file-id = 6377628
 project-id = 687577


### PR DESCRIPTION
## What
As the title says. Hopefully this will make grs writers reload their scripts without the need to delete caches everytime when they restart the game.

## Implementation Details
Some method rename and script re-location, that's mostly it

## Potential Compatibility Issues
GrS 1.2.3 contains a rewrite for groovy cl so should be aware there might be potential because of that.
