### PR TITLE
Add Fugue & Scalar to the pack

### DIFF
--- a/mods/fugue.pw.toml
+++ b/mods/fugue.pw.toml
@@ -1,0 +1,13 @@
+name = "Fugue"
+filename = "+Fugue-0.18.4.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "a868870e15b4647c5da21e2e0d954d60ff9e9d5f"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6382947
+project-id = 1005815

--- a/mods/scalar.pw.toml
+++ b/mods/scalar.pw.toml
@@ -1,0 +1,13 @@
+name = "Scalar"
+filename = "scalar-1.12.2-2.11.1-3.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "5ea811b41e0c5cc3bdaace91cfae102f4080aad9"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6130572
+project-id = 1012168


### PR DESCRIPTION
## What
Add mod Fugue & Scalar to the modpack, both of which won't load on normal forge instances, but are required for loading the game on cleanroom launcher.

## Outcome
This might enable ppl to run susy on crl easier, since now they only (hopefully) need to install the cleanroom relauncher.