### PR TITLE
Fixed missing recipes for steam-cracked naphthas and fixed HfO2 stoic

### DIFF
--- a/groovy/globals/Petrochemistry.groovy
+++ b/groovy/globals/Petrochemistry.groovy
@@ -167,6 +167,8 @@ class Petrochemistry {
         butane : new Crackable('butane').withTraits(SteamCrackable),
         light_cycle_oil : new Crackable('light_cycle_oil').withTraits(HydroCrackable).tap { hydrogen_consumed = 1100; gas_produced = 1290 },
         synthetic_wax : new Crackable('synthetic_wax').withTraits(HydroCrackable).tap { hydrogen_consumed = 7530; gas_produced = 1410 },
+        heavy_naphtha : new Crackable('heavy_naphtha').withTraits(SteamCrackable),
+        light_naphtha : new Crackable('light_naphtha').withTraits(SteamCrackable),
     ]
 
     public static oils = [

--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/d_block/group4/HafniumChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/d_block/group4/HafniumChain.groovy
@@ -41,7 +41,7 @@ ROASTER.recipeBuilder()
 
 for (highPurityCombustible in highPurityCombustibles()) {
         FLUIDIZED_BED_REACTOR.recipeBuilder()
-                .inputs(ore('dustHafniumDioxide'))
+                .inputs(ore('dustHafniumDioxide') * 3)
                 .inputs(ore(highPurityCombustible.name) * highPurityCombustible.equivalent(2))
                 .fluidInputs(fluid('chlorine') * 4000)
                 .outputs(metaitem('dustImpureHafniumTetrachloride') * 5)


### PR DESCRIPTION
## What
Steam-cracked light and heavy naphtha could be distilled but there were no recipes for them.
Impure HfCl4 recipe only used 1x HfO2 dust instead of 3.

## Outcome
Made light/heavy naphtha steam-crackable and updated the Impure HfCl4 recipe.

