### PR TITLE
Add ProjectRed to the pack

### DIFF
--- a/config/ProjectRed.cfg
+++ b/config/ProjectRed.cfg
@@ -1,0 +1,126 @@
+# Configuration file
+
+##########################################################################################################
+# compatibility
+#--------------------------------------------------------------------------------------------------------#
+# Control the loading of various compatibility hooks. These settings are ignored unless the Compatibility module is installed.
+##########################################################################################################
+
+compatibility {
+    # Registers ProjectRed decorative blocks with Chisel.
+    B:"Chisel: Decorative Blocks"=true
+
+    # This allows computers to connect to bundled cables with the RS API.
+    B:"ComputerCraft: Bundled Cables"=true
+
+    # This allows gem axes to work with treecapitator.
+    B:"Treecapitator: Gem Axe"=true
+}
+
+
+##########################################################################################################
+# general settings
+#--------------------------------------------------------------------------------------------------------#
+# Contains basic settings for the mod.
+##########################################################################################################
+
+"general settings" {
+    # If set to false, logic gates will not make sounds.
+    B:"Logic Sounds"=true
+
+    # Minimum amount of ticks the timer gates can be set to. Cannot be lower than 4.
+    I:"Minimum Timer Ticks"=4
+
+    # Ticks between router searches.
+    I:"Routed Pipes: Detection Frequency"=40
+
+    # Max number of pipes to explore when connecting to other routers.
+    I:"Routed Pipes: Max Detection Count"=100
+
+    # Maximum distance an item may aimlessly wander in a pipe before being erased. 0 for unlimited.
+    I:"Routed Pipes: Max Wander Distance"=0
+
+    # Number of active route table update threads.
+    I:"Routed Pipes: Update Threads"=4
+
+    # If set to true, sticks will be used instead of wood strips in framed wire recipes.
+    B:"Simple Framed Wire Recipe"=false
+
+    # If set to true, the basic screwdriver will not take damage.
+    B:"Unbreakable Screwdriver"=false
+}
+
+
+##########################################################################################################
+# machine settings
+#--------------------------------------------------------------------------------------------------------#
+# Contains settings related to machines and devices.
+##########################################################################################################
+
+"machine settings" {
+    # Allow the Diamond Block Breaker to be crafted.
+    B:"Enable the Diamond Block Breaker"=false
+}
+
+
+##########################################################################################################
+# render settings
+#--------------------------------------------------------------------------------------------------------#
+# Contains settings related to how things render in-game.
+##########################################################################################################
+
+"render settings" {
+    # If set to false, flat wire textures will be used for logic gates. Significant performance improvement.
+    B:"3D Logic Wires"=true
+
+    # Number of lights to render, -1 for unlimited
+    I:"Light Halo Render Count"=-1
+
+    # If set to false, routed pipes will not render routing fx such as bubbles and lasers.
+    B:"Routed Pipe FX"=true
+
+    # If set to false, gates will be rendered in the TESR rather than the WorldRenderer.
+    B:"Static Gates"=true
+
+    # If set to false, wires will be rendered in the TESR rather than the WorldRenderer.
+    B:"Static Wires"=true
+}
+
+
+##########################################################################################################
+# world gen
+#--------------------------------------------------------------------------------------------------------#
+# Contains settings related to world gen. You can enable/disable each ore or strucure, change retro generation settings, and increase how rare something is by increasing the resistance value.
+##########################################################################################################
+
+"world gen" {
+    B:"Copper Ore"=true
+    I:"Copper Ore resistance"=0
+    B:"Copper Ore retrogen"=false
+    B:"Electrotine Ore"=true
+    I:"Electrotine Ore resistance"=0
+    B:"Electrotine Ore retrogen"=false
+    B:"Marble Caves"=true
+    I:"Marble Caves resistance"=0
+    B:"Marble Caves retrogen"=false
+    B:"Peridot Ore"=true
+    I:"Peridot Ore resistance"=0
+    B:"Peridot Ore retrogen"=false
+    B:"Ruby Ore"=true
+    I:"Ruby Ore resistance"=0
+    B:"Ruby Ore retrogen"=false
+    B:"Sapphire Ore"=true
+    I:"Sapphire Ore resistance"=0
+    B:"Sapphire Ore retrogen"=false
+    B:"Silver Ore"=true
+    I:"Silver Ore resistance"=0
+    B:"Silver Ore retrogen"=false
+    B:"Tin Ore"=true
+    I:"Tin Ore resistance"=0
+    B:"Tin Ore retrogen"=false
+    I:"Volcano resistance"=0
+    B:"Volcano retrogen"=false
+    B:Volcanos=true
+}
+
+

--- a/config/ProjectRed.cfg
+++ b/config/ProjectRed.cfg
@@ -8,13 +8,13 @@
 
 compatibility {
     # Registers ProjectRed decorative blocks with Chisel.
-    B:"Chisel: Decorative Blocks"=true
+    B:"Chisel: Decorative Blocks"=false
 
     # This allows computers to connect to bundled cables with the RS API.
-    B:"ComputerCraft: Bundled Cables"=true
+    B:"ComputerCraft: Bundled Cables"=false
 
     # This allows gem axes to work with treecapitator.
-    B:"Treecapitator: Gem Axe"=true
+    B:"Treecapitator: Gem Axe"=false
 }
 
 
@@ -26,7 +26,7 @@ compatibility {
 
 "general settings" {
     # If set to false, logic gates will not make sounds.
-    B:"Logic Sounds"=true
+    B:"Logic Sounds"=false
 
     # Minimum amount of ticks the timer gates can be set to. Cannot be lower than 4.
     I:"Minimum Timer Ticks"=4
@@ -44,10 +44,10 @@ compatibility {
     I:"Routed Pipes: Update Threads"=4
 
     # If set to true, sticks will be used instead of wood strips in framed wire recipes.
-    B:"Simple Framed Wire Recipe"=false
+    B:"Simple Framed Wire Recipe"=true
 
     # If set to true, the basic screwdriver will not take damage.
-    B:"Unbreakable Screwdriver"=false
+    B:"Unbreakable Screwdriver"=true
 }
 
 
@@ -94,33 +94,32 @@ compatibility {
 ##########################################################################################################
 
 "world gen" {
-    B:"Copper Ore"=true
+    B:"Copper Ore"=false
     I:"Copper Ore resistance"=0
     B:"Copper Ore retrogen"=false
-    B:"Electrotine Ore"=true
+    B:"Electrotine Ore"=false
     I:"Electrotine Ore resistance"=0
     B:"Electrotine Ore retrogen"=false
-    B:"Marble Caves"=true
+    B:"Marble Caves"=false
     I:"Marble Caves resistance"=0
     B:"Marble Caves retrogen"=false
-    B:"Peridot Ore"=true
+    B:"Peridot Ore"=false
     I:"Peridot Ore resistance"=0
     B:"Peridot Ore retrogen"=false
-    B:"Ruby Ore"=true
+    B:"Ruby Ore"=false
     I:"Ruby Ore resistance"=0
     B:"Ruby Ore retrogen"=false
-    B:"Sapphire Ore"=true
+    B:"Sapphire Ore"=false
     I:"Sapphire Ore resistance"=0
     B:"Sapphire Ore retrogen"=false
-    B:"Silver Ore"=true
+    B:"Silver Ore"=false
     I:"Silver Ore resistance"=0
     B:"Silver Ore retrogen"=false
-    B:"Tin Ore"=true
+    B:"Tin Ore"=false
     I:"Tin Ore resistance"=0
     B:"Tin Ore retrogen"=false
     I:"Volcano resistance"=0
     B:"Volcano retrogen"=false
-    B:Volcanos=true
+    B:Volcanos=false
 }
-
 

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -376,7 +376,7 @@ ASSEMBLER.recipeBuilder()
 
 RecyclingHelper.addShaped("gregtech:steam_pump", metaitem('susy:pump.steam'), [
     [ore('screwBronze'), ore('rotorBronze'), ore('ringIron')],
-    [ore('toolScrewdriver'), ore('pipeTinyFluidBronze'), ore('toolWrench')],
+    [ore('craftingToolScrewdriver'), ore('pipeTinyFluidBronze'), ore('craftingToolWrench')],
     [ore('ringIron'), metaitem('steam.motor'), ore('pipeTinyFluidBronze')]
 ])
 

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -54,6 +54,7 @@ def name_removals = [
   'projectred-transmission:insulated/lime_insulated_wire',
   'projectred-transmission:insulated/purple_insulated_wire'
 ];
+
 for (name in name_removals) {
   crafting.remove(name)
 }

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -5,8 +5,14 @@ CHEMICAL_BATH = recipemap('chemical_bath')
 log.infoMC("Running projectRed.groovy...")
 
 mods.jei.ingredient.yeet(
+    item('projectred-core:resource_item', 100),         //Copper Ingot
+    item('projectred-core:resource_item', 101),         //Tin Ingot
+    item('projectred-core:resource_item', 102),         //Silver Ingot
+    item('projectred-core:resource_item', 103),         //Red Alloy Ingot
     item('projectred-core:resource_item', 104),         //Electrotine Alloy Ingot
     item('projectred-core:resource_item', 105),         //Electrotine
+    item('projectred-core:resource_item', 200),         //Ruby
+    item('projectred-core:resource_item', 201),         //Sapphire
     item('projectred-core:resource_item', 202),         //Peridot
     item('projectred-core:resource_item', 250),         //Sandy Coal Compound
     item('projectred-core:resource_item', 251),         //Red Iron Compound

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -194,7 +194,7 @@ CHEMICAL_BATH.recipeBuilder()
     .fluidInputs(fluid('redstone') * 1152)
     .outputs(item('projectred-core:resource_item:320'))
     .duration(400)
-    .EUt(6)
+    .EUt(7)
     .buildAndRegister();
 
 // Energized Silicon
@@ -205,7 +205,7 @@ CHEMICAL_BATH.recipeBuilder()
     .fluidInputs(fluid('glowstone') * 1152)
     .outputs(item('projectred-core:resource_item:341'))
     .duration(400)
-    .EUt(6)
+    .EUt(7)
     .buildAndRegister();
 
 // Silicon Chip
@@ -226,3 +226,52 @@ ASSEMBLER.recipeBuilder()
 
 //Black Insulated Wire
 crafting.addShapeless(item('projectred-transmission:wire:16'), [ore('cableGtSingleRedAlloy')]);
+
+def dyes = [
+    'dye_white',
+    'dye_orange',
+    'dye_magenta',
+    'dye_light_blue',
+    'dye_yellow',
+    'dye_lime',
+    'dye_pink',
+    'dye_grey',
+    'dye_light_grey',
+    'dye_cyan',
+    'dye_purple',
+    'dye_blue',
+    'dye_brown',
+    'dye_green',
+    'dye_red',
+    'dye_black'
+]
+for (i = 0; i < 15; i++) {
+	CHEMICAL_BATH.recipeBuilder()
+		.inputs(ore('projredInsulatedWire'))
+		.fluidInputs(fluid(dyes[i]) * 18)
+		.outputs(item('projectred-transmission:wire', [i+1]))
+		.duration(20)
+		.EUt(7)
+		.buildAndRegister();
+	CHEMICAL_BATH.recipeBuilder()
+		.inputs(ore('projredBundledCable'))
+		.fluidInputs(fluid(dyes[i]) * 18)
+		.outputs(item('projectred-transmission:wire', [i+18]))
+		.duration(20)
+		.EUt(7)
+		.buildAndRegister();
+	CHEMICAL_BATH.recipeBuilder()
+		.inputs(ore('projredBundledCable'))
+		.fluidInputs(fluid('acetone') * 100)
+		.outputs(item('projectred-transmission:wire', 17))
+		.duration(20)
+		.EUt(7)
+		.buildAndRegister();
+	CHEMICAL_BATH.recipeBuilder()
+		.inputs(ore('projredInsFrameWire'))
+		.fluidInputs(fluid(dyes[i]) * 18)
+		.outputs(item('projectred-transmission:framed_wire', [i+1]))
+		.duration(20)
+		.EUt(7)
+		.buildAndRegister();
+}

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -66,6 +66,14 @@ crafting.addShaped("projectred-core:circuit_plate", item('projectred-core:resour
 	[null, null, null]
 ])
 
+ASSEMBLER.recipeBuilder()
+	.inputs(ore('wireFineRedAlloy') * 3, ore('plateStone') * 3)
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+
 // Conductive Plate
 crafting.replaceShaped("projectred-core:parts/conductive_plate", item('projectred-core:resource_item:1'), [
 	[null, ore('plateRedAlloy'), null],
@@ -74,7 +82,7 @@ crafting.replaceShaped("projectred-core:parts/conductive_plate", item('projectre
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(metaitem('plateRedAlloy'), item('projectred-core:resource_item'))
+	.inputs(ore('plateRedAlloy'), item('projectred-core:resource_item'))
 	.circuitMeta(7)
 	.outputs(item('projectred-core:resource_item:1'))
 	.duration(100).EUt(VA[LV])
@@ -88,7 +96,7 @@ crafting.replaceShaped("projectred-core:parts/wired_plate", item('projectred-cor
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(metaitem('wireGtSingleRedAlloy'), item('projectred-core:resource_item'))
+	.inputs(ore('wireGtSingleRedAlloy'), item('projectred-core:resource_item'))
 	.circuitMeta(7)
 	.outputs(item('projectred-core:resource_item:2'))
 	.duration(100).EUt(VA[LV])
@@ -111,7 +119,7 @@ ASSEMBLER.recipeBuilder()
 // Platformed Plate
 crafting.replaceShaped("projectred-core:parts/platformed_plate", item('projectred-core:resource_item:4'), [
 	[null, item('projectred-core:resource_item'), null],
-	[item('projectred-core:resource_item:2'), ore('frameWood'), item('projectred-core:resource_item:2')],
+	[item('projectred-core:resource_item:2'), ore('frameGtWood'), item('projectred-core:resource_item:2')],
 	[item('projectred-core:resource_item'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item')]
 ])
 

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -227,7 +227,7 @@ ASSEMBLER.recipeBuilder()
 //Black Insulated Wire
 crafting.addShapeless(item('projectred-transmission:wire:16'), [ore('cableGtSingleRedAlloy')]);
 
-def dyes = [
+def chemical_dyes = [
     'dye_white',
     'dye_orange',
     'dye_magenta',
@@ -235,8 +235,8 @@ def dyes = [
     'dye_yellow',
     'dye_lime',
     'dye_pink',
-    'dye_grey',
-    'dye_light_grey',
+    'dye_gray',
+    'dye_light_gray',
     'dye_cyan',
     'dye_purple',
     'dye_blue',
@@ -245,33 +245,34 @@ def dyes = [
     'dye_red',
     'dye_black'
 ]
+
 for (i = 0; i < 15; i++) {
-	CHEMICAL_BATH.recipeBuilder()
-		.inputs(ore('projredInsulatedWire'))
-		.fluidInputs(fluid(dyes[i]) * 18)
-		.outputs(item('projectred-transmission:wire', [i+1]))
-		.duration(20)
-		.EUt(7)
-		.buildAndRegister();
-	CHEMICAL_BATH.recipeBuilder()
-		.inputs(ore('projredBundledCable'))
-		.fluidInputs(fluid(dyes[i]) * 18)
-		.outputs(item('projectred-transmission:wire', [i+18]))
-		.duration(20)
-		.EUt(7)
-		.buildAndRegister();
-	CHEMICAL_BATH.recipeBuilder()
-		.inputs(ore('projredBundledCable'))
-		.fluidInputs(fluid('acetone') * 100)
-		.outputs(item('projectred-transmission:wire', 17))
-		.duration(20)
-		.EUt(7)
-		.buildAndRegister();
-	CHEMICAL_BATH.recipeBuilder()
-		.inputs(ore('projredInsFrameWire'))
-		.fluidInputs(fluid(dyes[i]) * 18)
-		.outputs(item('projectred-transmission:framed_wire', [i+1]))
-		.duration(20)
-		.EUt(7)
-		.buildAndRegister();
+    CHEMICAL_BATH.recipeBuilder()
+        .inputs(ore('projredInsulatedWire'))
+        .fluidInputs(fluid(chemical_dyes[i]) * 18)
+        .outputs(item('projectred-transmission:wire', i+1))
+        .duration(20)
+        .EUt(7)
+        .buildAndRegister();
+    CHEMICAL_BATH.recipeBuilder()
+        .inputs(item('projectred-transmission:wire', i+18))
+        .fluidInputs(fluid('acetone') * 100)
+        .outputs(item('projectred-transmission:wire:17'))
+        .duration(20)
+        .EUt(7)
+        .buildAndRegister();
+    CHEMICAL_BATH.recipeBuilder()
+        .inputs(ore('projredBundledCable'))
+        .fluidInputs(fluid(chemical_dyes[i]) * 18)
+        .outputs(item('projectred-transmission:wire', i+18))
+        .duration(20)
+        .EUt(7)
+        .buildAndRegister();
+    CHEMICAL_BATH.recipeBuilder()
+        .inputs(ore('projredInsFramedWire'))
+        .fluidInputs(fluid(chemical_dyes[i]) * 18)
+        .outputs(item('projectred-transmission:framed_wire', i+1))
+        .duration(20)
+        .EUt(7)
+        .buildAndRegister();
 }

--- a/groovy/postInit/mod/ProjectRed.groovy
+++ b/groovy/postInit/mod/ProjectRed.groovy
@@ -5,28 +5,28 @@ CHEMICAL_BATH = recipemap('chemical_bath')
 log.infoMC("Running projectRed.groovy...")
 
 mods.jei.ingredient.yeet(
-	item('projectred-core:resource_item', 104),			//Electrotine Alloy Ingot
-	item('projectred-core:resource_item', 105),			//Electrotine
-	item('projectred-core:resource_item', 202),			//Peridot
-	item('projectred-core:resource_item', 250),			//Sandy Coal Compound
-	item('projectred-core:resource_item', 251),			//Red Iron Compound
-	item('projectred-core:resource_item', 252),			//Electrotine Iron Compound
-	item('projectred-core:resource_item', 300),			//Silicon
-	item('projectred-core:resource_item', 310),			//Red Silicon Compound
-	item('projectred-core:resource_item', 311),			//Glowing Silicon Compound
-	item('projectred-core:resource_item', 312),			//Electrotine Silicon Compound
-	item('projectred-core:resource_item', 342),			//Electro Silicon
-	item('projectred-core:resource_item', 400),			//Electro Silicon
-	item('projectred-core:resource_item', 401),			//Iron Coil
-	item('projectred-core:resource_item', 402),			//Gold Coil
-	item('projectred-core:resource_item', 410),			//Motor
-	item('projectred-core:resource_item', 421),			//Sail
-	item('projectred-core:resource_item', 600),			//Null-Logic Routing Chip
-	item('projectred-core:drawplate'),					//Draw Plate
-	item('projectred-core:multimeter'),					//Multimeter
-	item('projectred-integration:gate', 34),			//IC Gate
-	item('projectred-transmission:wire', 34),			//Low Load Power Line
-	item('projectred-transmission:framed_wire', 34),	//Framed Low Load Power Line
+    item('projectred-core:resource_item', 104),         //Electrotine Alloy Ingot
+    item('projectred-core:resource_item', 105),         //Electrotine
+    item('projectred-core:resource_item', 202),         //Peridot
+    item('projectred-core:resource_item', 250),         //Sandy Coal Compound
+    item('projectred-core:resource_item', 251),         //Red Iron Compound
+    item('projectred-core:resource_item', 252),         //Electrotine Iron Compound
+    item('projectred-core:resource_item', 300),         //Silicon
+    item('projectred-core:resource_item', 310),         //Red Silicon Compound
+    item('projectred-core:resource_item', 311),         //Glowing Silicon Compound
+    item('projectred-core:resource_item', 312),         //Electrotine Silicon Compound
+    item('projectred-core:resource_item', 342),         //Electro Silicon
+    item('projectred-core:resource_item', 400),         //Electro Silicon
+    item('projectred-core:resource_item', 401),         //Iron Coil
+    item('projectred-core:resource_item', 402),         //Gold Coil
+    item('projectred-core:resource_item', 410),         //Motor
+    item('projectred-core:resource_item', 421),         //Sail
+    item('projectred-core:resource_item', 600),         //Null-Logic Routing Chip
+    item('projectred-core:drawplate'),                  //Draw Plate
+    item('projectred-core:multimeter'),                 //Multimeter
+    item('projectred-integration:gate', 34),            //IC Gate
+    item('projectred-transmission:wire', 34),           //Low Load Power Line
+    item('projectred-transmission:framed_wire', 34),    //Framed Low Load Power Line
 )
 
 def name_removals = [
@@ -61,168 +61,168 @@ crafting.replaceShapeless("projectred-transmission:red_alloy_wire", item('projec
 furnace.removeByOutput(item('projectred-core:resource_item'))
 
 crafting.addShaped("projectred-core:circuit_plate", item('projectred-core:resource_item'), [
-	[ore('wireFineRedAlloy'), ore('wireFineRedAlloy'), ore('wireFineRedAlloy')],
-	[ore('plateStone'), ore('plateStone'), ore('plateStone')],
-	[null, null, null]
+    [ore('wireFineRedAlloy'), ore('wireFineRedAlloy'), ore('wireFineRedAlloy')],
+    [ore('plateStone'), ore('plateStone'), ore('plateStone')],
+    [null, null, null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(ore('wireFineRedAlloy') * 3, ore('plateStone') * 3)
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(ore('wireFineRedAlloy') * 3, ore('plateStone') * 3)
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 
 // Conductive Plate
 crafting.replaceShaped("projectred-core:parts/conductive_plate", item('projectred-core:resource_item:1'), [
-	[null, ore('plateRedAlloy'), null],
-	[null, item('projectred-core:resource_item'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('plateRedAlloy'), null],
+    [null, item('projectred-core:resource_item'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(ore('plateRedAlloy'), item('projectred-core:resource_item'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:1'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(ore('plateRedAlloy'), item('projectred-core:resource_item'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:1'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Wired Plate
 crafting.replaceShaped("projectred-core:parts/wired_plate", item('projectred-core:resource_item:2'), [
-	[null, ore('plateRedAlloy'), null],
-	[null, item('projectred-core:resource_item'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('plateRedAlloy'), null],
+    [null, item('projectred-core:resource_item'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(ore('wireGtSingleRedAlloy'), item('projectred-core:resource_item'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:2'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(ore('wireGtSingleRedAlloy'), item('projectred-core:resource_item'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:2'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Bundled Plate
 crafting.replaceShaped("projectred-transmission:bundled_plate", item('projectred-core:resource_item:3'), [
-	[null, ore('projredBundledCable'), null],
-	[null, item('projectred-core:resource_item'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('projredBundledCable'), null],
+    [null, item('projectred-core:resource_item'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item'), ore('projredBundledCable'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:3'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item'), ore('projredBundledCable'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:3'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Platformed Plate
 crafting.replaceShaped("projectred-core:parts/platformed_plate", item('projectred-core:resource_item:4'), [
-	[null, item('projectred-core:resource_item'), null],
-	[item('projectred-core:resource_item:2'), ore('frameGtWood'), item('projectred-core:resource_item:2')],
-	[item('projectred-core:resource_item'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item')]
+    [null, item('projectred-core:resource_item'), null],
+    [item('projectred-core:resource_item:2'), ore('frameGtWood'), item('projectred-core:resource_item:2')],
+    [item('projectred-core:resource_item'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item')]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 2) * 2, ore('frameGtWood'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:4'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 2) * 2, ore('frameGtWood'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:4'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Anode
 crafting.replaceShaped("projectred-core:parts/anode", item('projectred-core:resource_item:10'), [
-	[null, ore('plateRedstone'), null],
-	[null, item('projectred-core:resource_item'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('plateRedstone'), null],
+    [null, item('projectred-core:resource_item'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item'), ore('plateRedstone'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:10'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item'), ore('plateRedstone'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:10'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Cathode
 crafting.replaceShaped("projectred-core:parts/cathode", item('projectred-core:resource_item:11'), [
-	[null, ore('boltRedAlloy'), null],
-	[null, item('projectred-core:resource_item'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('boltRedAlloy'), null],
+    [null, item('projectred-core:resource_item'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item'), ore('boltRedAlloy'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:11'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item'), ore('boltRedAlloy'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:11'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Pointer
 crafting.replaceShaped("projectred-core:parts/pointer", item('projectred-core:resource_item:12'), [
-	[null, ore('circuitUlv'), null],
-	[null, item('projectred-core:resource_item:11'), null],
-	[null, ore('craftingToolScrewdriver'), null]
+    [null, ore('circuitUlv'), null],
+    [null, item('projectred-core:resource_item:11'), null],
+    [null, ore('craftingToolScrewdriver'), null]
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(ore('circuitUlv'), item('projectred-core:resource_item'))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item:12'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(ore('circuitUlv'), item('projectred-core:resource_item'))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item:12'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Bus Input Panel
 crafting.replaceShaped("projectred-integration:bus_input_panel", item('projectred-integration:gate:30'), [
-	[item('projectred-core:resource_item:3'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item:3')],
-	[item('projectred-core:resource_item:3'), metaitem('cover.screen'), item('projectred-core:resource_item:3')],
-	[item('projectred-core:resource_item:3'), ore('circuitLv'), item('projectred-core:resource_item:3')],
+    [item('projectred-core:resource_item:3'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item:3')],
+    [item('projectred-core:resource_item:3'), metaitem('cover.screen'), item('projectred-core:resource_item:3')],
+    [item('projectred-core:resource_item:3'), ore('circuitLv'), item('projectred-core:resource_item:3')],
 ])
 
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item:3') * 6, metaitem('cover.screen'), metaitem('cover.screen'))
-	.circuitMeta(7)
-	.outputs(item('projectred-integration:gate:30'))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item:3') * 6, metaitem('cover.screen'), metaitem('cover.screen'))
+    .circuitMeta(7)
+    .outputs(item('projectred-integration:gate:30'))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Infused Silicon
 furnace.removeByOutput(item('projectred-core:resource_item:320'))
 
 CHEMICAL_BATH.recipeBuilder()
-	.inputs(metaitem('plate.integrated_logic_circuit'))
-	.fluidInputs(fluid('redstone') * 1152)
-	.outputs(item('projectred-core:resource_item:320'))
-	.duration(400)
-	.EUt(6)
-	.buildAndRegister();
+    .inputs(metaitem('plate.integrated_logic_circuit'))
+    .fluidInputs(fluid('redstone') * 1152)
+    .outputs(item('projectred-core:resource_item:320'))
+    .duration(400)
+    .EUt(6)
+    .buildAndRegister();
 
 // Energized Silicon
 furnace.removeByOutput(item('projectred-core:resource_item:341'))
 
 CHEMICAL_BATH.recipeBuilder()
-	.inputs(metaitem('plate.integrated_logic_circuit'))
-	.fluidInputs(fluid('glowstone') * 1152)
-	.outputs(item('projectred-core:resource_item:341'))
-	.duration(400)
-	.EUt(6)
-	.buildAndRegister();
+    .inputs(metaitem('plate.integrated_logic_circuit'))
+    .fluidInputs(fluid('glowstone') * 1152)
+    .outputs(item('projectred-core:resource_item:341'))
+    .duration(400)
+    .EUt(6)
+    .buildAndRegister();
 
 // Silicon Chip
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 320))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item', 20))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 320))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item', 20))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 // Energized Silicon Chip
 ASSEMBLER.recipeBuilder()
-	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 341))
-	.circuitMeta(7)
-	.outputs(item('projectred-core:resource_item', 21))
-	.duration(100).EUt(VA[LV])
-	.buildAndRegister()
+    .inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 341))
+    .circuitMeta(7)
+    .outputs(item('projectred-core:resource_item', 21))
+    .duration(100).EUt(VA[LV])
+    .buildAndRegister()
 
 //Black Insulated Wire
 crafting.addShapeless(item('projectred-transmission:wire:16'), [ore('cableGtSingleRedAlloy')]);

--- a/groovy/postInit/mod/projectRed.groovy
+++ b/groovy/postInit/mod/projectRed.groovy
@@ -1,0 +1,220 @@
+import static gregtech.api.GTValues.*
+ASSEMBLER = recipemap('assembler')
+CHEMICAL_BATH = recipemap('chemical_bath')
+
+log.infoMC("Running projectRed.groovy...")
+
+mods.jei.ingredient.yeet(
+	item('projectred-core:resource_item', 104),			//Electrotine Alloy Ingot
+	item('projectred-core:resource_item', 105),			//Electrotine
+	item('projectred-core:resource_item', 202),			//Peridot
+	item('projectred-core:resource_item', 250),			//Sandy Coal Compound
+	item('projectred-core:resource_item', 251),			//Red Iron Compound
+	item('projectred-core:resource_item', 252),			//Electrotine Iron Compound
+	item('projectred-core:resource_item', 300),			//Silicon
+	item('projectred-core:resource_item', 310),			//Red Silicon Compound
+	item('projectred-core:resource_item', 311),			//Glowing Silicon Compound
+	item('projectred-core:resource_item', 312),			//Electrotine Silicon Compound
+	item('projectred-core:resource_item', 342),			//Electro Silicon
+	item('projectred-core:resource_item', 400),			//Electro Silicon
+	item('projectred-core:resource_item', 401),			//Iron Coil
+	item('projectred-core:resource_item', 402),			//Gold Coil
+	item('projectred-core:resource_item', 410),			//Motor
+	item('projectred-core:resource_item', 421),			//Sail
+	item('projectred-core:resource_item', 600),			//Null-Logic Routing Chip
+	item('projectred-core:drawplate'),					//Draw Plate
+	item('projectred-core:multimeter'),					//Multimeter
+	item('projectred-integration:gate', 34),			//IC Gate
+	item('projectred-transmission:wire', 34),			//Low Load Power Line
+	item('projectred-transmission:framed_wire', 34),	//Framed Low Load Power Line
+)
+
+def name_removals = [
+  'projectred-transmission:insulated/green_insulated_wire',
+  'projectred-transmission:insulated/cyan_insulated_wire',
+  'projectred-transmission:insulated/yellow_insulated_wire',
+  'projectred-transmission:insulated/blue_insulated_wire',
+  'projectred-transmission:insulated/light_gray_insulated_wire',
+  'projectred-transmission:insulated/orange_insulated_wire',
+  'projectred-transmission:insulated/gray_insulated_wire',
+  'projectred-transmission:insulated/pink_insulated_wire',
+  
+  'projectred-transmission:insulated/magenta_insulated_wire',
+  'projectred-transmission:insulated/brown_insulated_wire',
+  'projectred-transmission:insulated/light_blue_insulated_wire',
+  'projectred-transmission:insulated/white_insulated_wire',
+  'projectred-transmission:insulated/red_insulated_wire',
+  'projectred-transmission:insulated/black_insulated_wire',
+  'projectred-transmission:insulated/lime_insulated_wire',
+  'projectred-transmission:insulated/purple_insulated_wire'
+];
+for (name in name_removals) {
+  crafting.remove(name)
+}
+
+// Recipes
+
+// Red Alloy Wire
+crafting.replaceShapeless("projectred-transmission:red_alloy_wire", item('projectred-transmission:wire'), [ore('wireGtSingleRedAlloy')])
+
+// Circuit Plate
+furnace.removeByOutput(item('projectred-core:resource_item'))
+
+crafting.addShaped("projectred-core:circuit_plate", item('projectred-core:resource_item'), [
+	[ore('wireFineRedAlloy'), ore('wireFineRedAlloy'), ore('wireFineRedAlloy')],
+	[ore('plateStone'), ore('plateStone'), ore('plateStone')],
+	[null, null, null]
+])
+
+// Conductive Plate
+crafting.replaceShaped("projectred-core:parts/conductive_plate", item('projectred-core:resource_item:1'), [
+	[null, ore('plateRedAlloy'), null],
+	[null, item('projectred-core:resource_item'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(metaitem('plateRedAlloy'), item('projectred-core:resource_item'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:1'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Wired Plate
+crafting.replaceShaped("projectred-core:parts/wired_plate", item('projectred-core:resource_item:2'), [
+	[null, ore('plateRedAlloy'), null],
+	[null, item('projectred-core:resource_item'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(metaitem('wireGtSingleRedAlloy'), item('projectred-core:resource_item'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:2'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Bundled Plate
+crafting.replaceShaped("projectred-transmission:bundled_plate", item('projectred-core:resource_item:3'), [
+	[null, ore('projredBundledCable'), null],
+	[null, item('projectred-core:resource_item'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item'), ore('projredBundledCable'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:3'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Platformed Plate
+crafting.replaceShaped("projectred-core:parts/platformed_plate", item('projectred-core:resource_item:4'), [
+	[null, item('projectred-core:resource_item'), null],
+	[item('projectred-core:resource_item:2'), ore('frameWood'), item('projectred-core:resource_item:2')],
+	[item('projectred-core:resource_item'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item')]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 2) * 2, ore('frameGtWood'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:4'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Anode
+crafting.replaceShaped("projectred-core:parts/anode", item('projectred-core:resource_item:10'), [
+	[null, ore('plateRedstone'), null],
+	[null, item('projectred-core:resource_item'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item'), ore('plateRedstone'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:10'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Cathode
+crafting.replaceShaped("projectred-core:parts/cathode", item('projectred-core:resource_item:11'), [
+	[null, ore('boltRedAlloy'), null],
+	[null, item('projectred-core:resource_item'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item'), ore('boltRedAlloy'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:11'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Pointer
+crafting.replaceShaped("projectred-core:parts/pointer", item('projectred-core:resource_item:12'), [
+	[null, ore('circuitUlv'), null],
+	[null, item('projectred-core:resource_item:11'), null],
+	[null, ore('craftingToolScrewdriver'), null]
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(ore('circuitUlv'), item('projectred-core:resource_item'))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item:12'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Bus Input Panel
+crafting.replaceShaped("projectred-integration:bus_input_panel", item('projectred-integration:gate:30'), [
+	[item('projectred-core:resource_item:3'), ore('craftingToolScrewdriver'), item('projectred-core:resource_item:3')],
+	[item('projectred-core:resource_item:3'), metaitem('cover.screen'), item('projectred-core:resource_item:3')],
+	[item('projectred-core:resource_item:3'), ore('circuitLv'), item('projectred-core:resource_item:3')],
+])
+
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item:3') * 6, metaitem('cover.screen'), metaitem('cover.screen'))
+	.circuitMeta(7)
+	.outputs(item('projectred-integration:gate:30'))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Infused Silicon
+furnace.removeByOutput(item('projectred-core:resource_item:320'))
+
+CHEMICAL_BATH.recipeBuilder()
+	.inputs(metaitem('plate.integrated_logic_circuit'))
+	.fluidInputs(fluid('redstone') * 1152)
+	.outputs(item('projectred-core:resource_item:320'))
+	.duration(400)
+	.EUt(6)
+	.buildAndRegister();
+
+// Energized Silicon
+furnace.removeByOutput(item('projectred-core:resource_item:341'))
+
+CHEMICAL_BATH.recipeBuilder()
+	.inputs(metaitem('plate.integrated_logic_circuit'))
+	.fluidInputs(fluid('glowstone') * 1152)
+	.outputs(item('projectred-core:resource_item:341'))
+	.duration(400)
+	.EUt(6)
+	.buildAndRegister();
+
+// Silicon Chip
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 320))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item', 20))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+// Energized Silicon Chip
+ASSEMBLER.recipeBuilder()
+	.inputs(item('projectred-core:resource_item') * 3, item('projectred-core:resource_item', 341))
+	.circuitMeta(7)
+	.outputs(item('projectred-core:resource_item', 21))
+	.duration(100).EUt(VA[LV])
+	.buildAndRegister()
+
+//Black Insulated Wire
+crafting.addShapeless(item('projectred-transmission:wire:16'), [ore('cableGtSingleRedAlloy')]);

--- a/index.toml
+++ b/index.toml
@@ -1,11 +1,1 @@
 hash-format = "sha256"
-
-[[files]]
-file = "mods/icbm.pw.toml"
-hash = "390df4cc0c3633bf3e6603de34e53727838eb9e26c22567791fab97ee681ddc5"
-metafile = true
-
-[[files]]
-file = "mods/susycore.pw.toml"
-hash = "e21b5c6e9ef61301b6a0d35aba120709d669d551651c933004d2f4929339484d"
-metafile = true

--- a/mods/cb-multipart.pw.toml
+++ b/mods/cb-multipart.pw.toml
@@ -1,0 +1,13 @@
+name = "CB Multipart"
+filename = "ForgeMultipart-1.12.2-2.6.2.83-universal.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "3306ea22380bc9b6a0170b23fa0251085d5a6e25"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2755790
+project-id = 258426

--- a/mods/mrtjpcore.pw.toml
+++ b/mods/mrtjpcore.pw.toml
@@ -1,0 +1,13 @@
+name = "MrTJPCore"
+filename = "MrTJPCore-1.12.2-2.1.4.43-universal.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "981382e6c623e8fe68cee07c8ee1f6f2c77b94dd"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2735197
+project-id = 229002

--- a/mods/project-red-core.pw.toml
+++ b/mods/project-red-core.pw.toml
@@ -1,0 +1,13 @@
+name = "Project Red - Core"
+filename = "ProjectRed-1.12.2-4.9.4.120-Base.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "11168221284c53b89363e93ab36110a29c26c1a2"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2745545
+project-id = 228702

--- a/mods/project-red-illumination.pw.toml
+++ b/mods/project-red-illumination.pw.toml
@@ -1,0 +1,13 @@
+name = "Project Red - Illumination"
+filename = "ProjectRed-1.12.2-4.9.4.120-lighting.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "41e17cd9ad1a6a27767df0a2366972f181d9ff89"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2745549
+project-id = 229046

--- a/mods/project-red-integration.pw.toml
+++ b/mods/project-red-integration.pw.toml
@@ -1,0 +1,13 @@
+name = "Project Red - Integration"
+filename = "ProjectRed-1.12.2-4.9.4.120-integration.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "f05cda479b14d41e02120295b4bcbb0ab25738d2"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2745548
+project-id = 229045


### PR DESCRIPTION
- Added Gregified recipes for ProjectRed-Core and ProjectRed-Transmission
(credits to https://github.com/Nomi-CEu/Nomi-CEu/blob/main/overrides/scripts/ProjectRed.zs and https://github.com/Nomi-CEu/Nomi-CEu/blob/main/overrides/groovy/postInit/main/modSpecific/projectRed.groovy)

Optional goals:
- Gregify recipes for ProjectRed-Illumination and ProjectRed-Fabrication