### PR TITLE
Upgrade release script for CF uploads

### DIFF
--- a/.github/scripts/extract_changelog.py
+++ b/.github/scripts/extract_changelog.py
@@ -1,0 +1,39 @@
+import sys
+import re
+import os
+
+def extract_changelog_section(changelog_path, version):
+    try:
+        with open(changelog_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+        
+        # Create a pattern to match the specific version header and its content
+        # up to the next version header (or end of file)
+        pattern = fr'# UPDATE {re.escape(version)}.*?(?=# UPDATE |\Z)'
+        
+        # Use re.DOTALL to match across multiple lines
+        match = re.search(pattern, content, re.DOTALL)
+        
+        if match:
+            return match.group(0).strip()
+        else:
+            print(f"Error: No changelog entry found for version {version}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error reading changelog: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Check if version argument was provided
+    version = os.environ.get("VERSION")
+ 
+    # Default changelog path or provided path
+    changelog_path = "CHANGELOG.md"
+    
+    if not os.path.exists(changelog_path):
+        print(f"Error: Changelog file not found at {changelog_path}")
+        sys.exit(1)
+    
+    changelog_section = extract_changelog_section(changelog_path, version)
+    changelog_section += "Download the server and client on [GitHub](https://github.com/SymmetricDevs/Supersymmetry/releases/tag/{version})!"
+    print(changelog_section)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,18 @@ jobs:
             }
       - run: echo "${{steps.get-version.outputs.result}}"
 
+      - name: Check if release tag already exists
+        id: check-tag
+        uses: mukunku/tag-exists-action@v1.6.0
+        with: 
+          tag: "v${{ steps.get-version.outputs.result }}"
+
+      - name: If so, fail workflow
+        if: steps.check-tag.outputs.exists == 'true'
+        run: |
+          echo "Error: Tag v${{ steps.get-version.outputs.result }} already exists! Please update pack.toml to change the version number."
+          exit 1
+
       - name: Rename file
         run: |
           mv buildOut/client.zip buildOut/supersymmetry-${{steps.get-version.outputs.result}}.zip
@@ -55,14 +67,40 @@ jobs:
           rm -f buildOut/client.zip
           rm -f buildOut/server.zip
 
-      - name: Automatic Releases
-        uses: marvinpinto/action-automatic-releases@latest
+      - name: Extract changelog for version
+        id: extract-changelog
+        run: |
+          chmod +x .github/scripts/extract_changelog.py
+          python .github/scripts/extract_changelog.py
+    
+      - name: Publish to Curseforge
+        id: curseforge-upload
+        uses: itsmeow/curseforge-upload@v3
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.get-version.outputs.result }}
-          prerelease: false
-          title: ${{ steps.get-version.outputs.result }}
-          files: |
+          file_path: "buildOut/supersymmetry-${{steps.get-version.outputs.result}}.zip"
+          game_endpoint: "minecraft"
+          game_versions: "Minecraft 1.12:1.12.2,Java 8,Forge"
+          project_id: "849321"
+          token: "${{ secrets.CFAPIKEY }}"
+          changelog: "${{ steps.extract_changelog.outputs.changelog }}"
+          changelog_type: "markdown"
+
+      - name: Publish to GitHub
+        uses: ncipollo/release-action@v1
+        with:
+          body: "${{ steps.extract_changelog.outputs.changelog }}\nThis will also be available in a few minutes on [CurseForge](https://www.curseforge.com/minecraft/modpacks/supersymmetry/files/${{ steps.curseforge-upload.outputs.id }})."
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.get-version.outputs.result }}
+          commit: ${{ github.ref }}
+          artifacts: |
             buildOut/supersymmetry-${{steps.get-version.outputs.result}}.zip
             buildOut/server-${{steps.get-version.outputs.result}}.zip
             buildOut/modlist.html
+          name: Release ${{ steps.get-version.outputs.result }}
+
+      - name: Publish to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@0.3.2
+        with: 
+          args: '${{ steps.extract_changelog.outputs.changelog }}\nThis will also be available in a few minutes on [CurseForge](https://www.curseforge.com/minecraft/modpacks/supersymmetry/files/${{ steps.curseforge-upload.outputs.id }}).'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# UPDATE 0.1.14.6.2
+
+Actually fixes the previous issue.
+
+# UPDATE 0.1.14.6.1
+
+Test


### PR DESCRIPTION
This makes several changes to the release.yaml workflow to automatically upload the modpack to CurseForge, add a changelog to each GitHub release, _and_ create a Discord announcement about it.