### PR TITLE
Ingot quest icons

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/0/13.json
+++ b/config/betterquesting/DefaultQuests/Quests/0/13.json
@@ -8,7 +8,6 @@
       "frame:8": "GATE",
       "icon:10": {
         "Damage:2": 25,
-        "OreDict:8": "ingotCopper",
         "id:8": "gregtech:meta_ingot"
       },
       "ismain:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/0/14.json
+++ b/config/betterquesting/DefaultQuests/Quests/0/14.json
@@ -8,7 +8,6 @@
       "frame:8": "GATE",
       "icon:10": {
         "Damage:2": 112,
-        "OreDict:8": "ingotTin",
         "id:8": "gregtech:meta_ingot"
       },
       "ismain:1": 1,


### PR DESCRIPTION
For whatever reason the quest icons for the copper and tin chapter 0 quests (it's actually all the ingot quests but it's only an issue for these two) are set to the oreDict ingotCopper/Tin instead of only the gregtech ingot item. As a result, it's flashing between the gregtech and projectRed copper and tin ingots, which is obviously very ungreggy and also annoying. 