### PR TITLE
Fixed missing GasTier import; fixed missing metaitem key

### DIFF
--- a/groovy/material/SecondDegreeMaterials.groovy
+++ b/groovy/material/SecondDegreeMaterials.groovy
@@ -13,6 +13,7 @@ import supersymmetry.api.util.SuSyUtility;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.Materials.*;
+import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import static gregtechfoodoption.GTFOMaterialHandler.*;
 import static supersymmetry.api.unification.material.info.SuSyMaterialFlags.*;
 

--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -529,7 +529,7 @@ RecyclingHelper.addShaped("gregtech:fermentation_vat", metaitem('fermentation_va
 
 for (i = 1; i <= 8; i++) {
     RecyclingHelper.addShaped("gregtech:uv_light_box." + Globals.voltageTiers[i], metaitem('uv_light_box.' + Globals.voltageTiers[i]), [
-        [tieredCables[i], metaitem('lamp.carbon_filament'), tieredCables[i]],
+        [tieredCables[i], metaitem('carbon_arc_lamp'), tieredCables[i]],
         [circuits[i], hulls[i], circuits[i]],
         [tieredPlates[i], tieredPlates[i], tieredPlates[i]]
     ])


### PR DESCRIPTION
## What
The latest pre-release was not loading properly due to a missing import in SecondDegreeMaterials.
Warnings appeared for a missing lamp.carbon_filament metaitem (was renamed from carbon_arc_lamp in MachineRecipes).

## Outcome
Added the missing GasTier import and changed the metaitem key back so it matches the registration and lang files.

