### PR TITLE
Change circuit board patterning circuit

### DIFF
--- a/groovy/postInit/components/EtchablesChain.groovy
+++ b/groovy/postInit/components/EtchablesChain.groovy
@@ -474,7 +474,7 @@ FORMING_PRESS.recipeBuilder()
         .EUt(30)
         .buildAndRegister()
 
-generatePatterningRecipes('laminated.board.phenolic', 'patterned.board.phenolic', 'mask.pcb', 1, 1, 1, 0, false)
+generatePatterningRecipes('laminated.board.phenolic', 'patterned.board.phenolic', 'mask.pcb', 1, 1, 1, 10, false)
 generateEtchingRecipes('patterned.board.phenolic', 'circuit_board.good', 'copper', 1, 1, false)
 
 //PLASTIC CIRCUIT BOARD (TIER 3)
@@ -511,7 +511,7 @@ FORMING_PRESS.recipeBuilder()
         .EUt(30)
         .buildAndRegister()
 
-generatePatterningRecipes('board.plastic', 'patterned.board.plastic', 'mask.pcb', 2, 1, 1, 0, false)
+generatePatterningRecipes('board.plastic', 'patterned.board.plastic', 'mask.pcb', 2, 1, 1, 10, false)
 generateEtchingRecipes('patterned.board.plastic', 'circuit_board.plastic', 'copper', 2, 1, false)
 
 //NAND AND NOR


### PR DESCRIPTION
## What
Changes circuit board patterning Meta circuit number

It used to have circuit number 0 but that isn't usable with ghost circuits.