### PR TITLE
feat: recipes for locomotive controller + exchangers

### DIFF
--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -1290,3 +1290,23 @@ RecyclingHelper.handleRecycling(metaitem('combustion_generator.hv'), [
     ore('gearStainlessSteel') * 2,
     ore('pipeHugeFluidStainlessSteel'),
 ])
+
+// Train interfaces
+def rail = ore('stickLongSteel')
+crafting.addShaped("gt_fluid_loader", metaitem('stock_fluid_exchanger'), [
+		[null, metaitem('electric.pump.lv'), null],
+		[rail, metaitem('hull.lv'), rail],
+		[null, null, null]
+]);
+
+crafting.addShaped("gt_item_loader", metaitem('stock_item_exchanger'), [
+		[null, metaitem('conveyor.module.lv'), null],
+		[rail, metaitem('hull.lv'), rail],
+		[null, null, null]
+]);
+
+crafting.addShaped("gt_locomotive_controller", metaitem('stock_controller'), [
+		[rail, metaitem('sensor.lv'), rail],
+		[rail, metaitem('hull.lv'), rail],
+		[rail, ore('circuitLv'), rail]
+]);

--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -1293,20 +1293,20 @@ RecyclingHelper.handleRecycling(metaitem('combustion_generator.hv'), [
 
 // Train interfaces
 def rail = ore('stickLongSteel')
-crafting.addShaped("gt_fluid_loader", metaitem('stock_fluid_exchanger'), [
-		[null, metaitem('electric.pump.lv'), null],
-		[rail, metaitem('hull.lv'), rail],
-		[null, null, null]
+crafting.addShaped("gregtech:fluid_loader", metaitem('stock_fluid_exchanger'), [
+		[ore('craftingToolHardHammer'), metaitem('electric.pump.lv'), ore('craftingToolWrench')],
+		[ore('pipeSmallFluidSteel'), metaitem('hull.lv'), ore('pipeSmallFluidSteel')],
+		[ore('pipeSmallFluidSteel'), metaitem('conveyor.lv'), ore('pipeSmallFluidSteel')]
 ]);
 
-crafting.addShaped("gt_item_loader", metaitem('stock_item_exchanger'), [
-		[null, metaitem('conveyor.module.lv'), null],
-		[rail, metaitem('hull.lv'), rail],
-		[null, null, null]
+crafting.addShaped("gregtech:item_loader", metaitem('stock_item_exchanger'), [
+		[ore('craftingToolHardHammer'), ore('circuitLv'), ore('craftingToolWrench')],
+		[ore('pipeSmallNickel'), metaitem('hull.lv'), ore('pipeSmallNickel')],
+		[ore('pipeSmallNickel'), metaitem('pump.lv'), ore('pipeSmallNickel')]
 ]);
 
-crafting.addShaped("gt_locomotive_controller", metaitem('stock_controller'), [
-		[rail, metaitem('sensor.lv'), rail],
-		[rail, metaitem('hull.lv'), rail],
-		[rail, ore('circuitLv'), rail]
+crafting.addShaped("gregtech:locomotive_controller", metaitem('stock_controller'), [
+		[ore('craftingToolHardHammer'), ore('circuitLv'), ore('craftingToolWrench')],
+		[ore('pipeSmallNickel'), metaitem('hull.lv'), ore('pipeSmallNickel')],
+		[metaitem('emitter.lv'), ore('circuitLv'), metaitem('sensor.lv')]
 ]);

--- a/groovy/postInit/mod/MachineRecipes.groovy
+++ b/groovy/postInit/mod/MachineRecipes.groovy
@@ -1292,21 +1292,20 @@ RecyclingHelper.handleRecycling(metaitem('combustion_generator.hv'), [
 ])
 
 // Train interfaces
-def rail = ore('stickLongSteel')
-crafting.addShaped("gregtech:fluid_loader", metaitem('stock_fluid_exchanger'), [
+RecyclingHelper.addShaped("gregtech:fluid_loader", metaitem('stock_fluid_exchanger'), [
 		[ore('craftingToolHardHammer'), metaitem('electric.pump.lv'), ore('craftingToolWrench')],
 		[ore('pipeSmallFluidSteel'), metaitem('hull.lv'), ore('pipeSmallFluidSteel')],
-		[ore('pipeSmallFluidSteel'), metaitem('conveyor.lv'), ore('pipeSmallFluidSteel')]
-]);
+		[ore('pipeSmallFluidSteel'), metaitem('conveyor.module.lv'), ore('pipeSmallFluidSteel')]
+])
 
-crafting.addShaped("gregtech:item_loader", metaitem('stock_item_exchanger'), [
+RecyclingHelper.addShaped("gregtech:item_loader", metaitem('stock_item_exchanger'), [
 		[ore('craftingToolHardHammer'), ore('circuitLv'), ore('craftingToolWrench')],
-		[ore('pipeSmallNickel'), metaitem('hull.lv'), ore('pipeSmallNickel')],
-		[ore('pipeSmallNickel'), metaitem('pump.lv'), ore('pipeSmallNickel')]
-]);
+		[ore('pipeSmallItemNickel'), metaitem('hull.lv'), ore('pipeSmallItemNickel')],
+		[ore('pipeSmallItemNickel'), metaitem('electric.pump.lv'), ore('pipeSmallItemNickel')]
+])
 
-crafting.addShaped("gregtech:locomotive_controller", metaitem('stock_controller'), [
+RecyclingHelper.addShaped("gregtech:locomotive_controller", metaitem('stock_controller'), [
 		[ore('craftingToolHardHammer'), ore('circuitLv'), ore('craftingToolWrench')],
-		[ore('pipeSmallNickel'), metaitem('hull.lv'), ore('pipeSmallNickel')],
+		[ore('pipeSmallItemNickel'), metaitem('hull.lv'), ore('pipeSmallItemNickel')],
 		[metaitem('emitter.lv'), ore('circuitLv'), metaitem('sensor.lv')]
-]);
+])


### PR DESCRIPTION
Adds some recipes for SuSyCore's locomotive controller, item exchanger, and fluid exchanger (all for IR).
Here they are:
![image](https://github.com/user-attachments/assets/00668f39-53ed-4b71-9383-c6826260bc1e)
They are based off of the IR equivalents.
I can add a quest if requested.