### PR TITLE
feat: remove techguns slot

### DIFF
--- a/config/techguns.cfg
+++ b/config/techguns.cfg
@@ -117,7 +117,7 @@ general {
     B:debug=false
 
     # Disable automatic feeding of Food in the Techguns tab. Disable autofeeding if you think it breaks the balance [default: false]
-    B:disableAutofeeder=false
+    B:disableAutofeeder=true
 
     # Keep recipes with lava instead of fuel even when fuel is present. Fuels need to be added by other mods [default: false]
     B:keepLavaRecipesWhenFuelIsPresent=false


### PR DESCRIPTION
Simply turns off the automatic feeding slot. The slots still exist, but they do not actually refill hunger automatically.