### PR TITLE
Disable Techguns food slot functionality

### DIFF
--- a/config/techguns.cfg
+++ b/config/techguns.cfg
@@ -117,7 +117,7 @@ general {
     B:debug=false
 
     # Disable automatic feeding of Food in the Techguns tab. Disable autofeeding if you think it breaks the balance [default: false]
-    B:disableAutofeeder=false
+    B:disableAutofeeder=true
 
     # Keep recipes with lava instead of fuel even when fuel is present. Fuels need to be added by other mods [default: false]
     B:keepLavaRecipesWhenFuelIsPresent=false


### PR DESCRIPTION
## What
Keeps the slots and everything in it but disables the autofeed mechanic