### PR TITLE
Update GasPunk.groovy

### DIFF
--- a/groovy/postInit/mod/GasPunk.groovy
+++ b/groovy/postInit/mod/GasPunk.groovy
@@ -58,10 +58,11 @@ Globals.solders.each { key, val ->
             .inputs([
                 ore(rubber_ring)*4,
                 ore('platePlastic'),
+                metaitem('component.glass.tube'),
                 ore('plateSteel')
             ])
             .fluidInputs(fluid(key) * val)
-            .outputs(item('gaspunk:diffuser'))
+            .outputs(item('gaspunk:grenade'))
             .duration(200)
             .EUt(60)
             .buildAndRegister();
@@ -131,7 +132,7 @@ for (key in GasMapMV) {
             .buildAndRegister();
 
     mods.gregtech.canner.recipeBuilder()
-            .inputs([item('gaspunk:diffuser')])
+            .inputs([item('gaspunk:grenade')])
             .fluidInputs(liquid(key.getKey())*100)
             .outputs(item('gaspunk:grenade').withNbt(["gaspunk:contained_gas": GasMapMV[key.getKey()]]))
             .duration(20)

--- a/groovy/postInit/mod/GasPunk.groovy
+++ b/groovy/postInit/mod/GasPunk.groovy
@@ -58,11 +58,11 @@ Globals.solders.each { key, val ->
             .inputs([
                 ore(rubber_ring)*4,
                 ore('platePlastic'),
-                metaitem('component.glass.tube'),
-                ore('plateSteel')
+                ore('plateSteel'),
+                metaitem('component.glass.tube')
             ])
             .fluidInputs(fluid(key) * val)
-            .outputs(item('gaspunk:grenade'))
+            .outputs(item('gaspunk:empty_grenade'))
             .duration(200)
             .EUt(60)
             .buildAndRegister();
@@ -132,7 +132,7 @@ for (key in GasMapMV) {
             .buildAndRegister();
 
     mods.gregtech.canner.recipeBuilder()
-            .inputs([item('gaspunk:grenade')])
+            .inputs([item('gaspunk:empty_grenade')])
             .fluidInputs(liquid(key.getKey())*100)
             .outputs(item('gaspunk:grenade').withNbt(["gaspunk:contained_gas": GasMapMV[key.getKey()]]))
             .duration(20)


### PR DESCRIPTION
Why ? Diffuser doesn't have glass, yet the glass part appears out of nowhere when filling it with canning. Using filled grenade drops empty one but it is then completely useless because it has no recipe to fill it back. This PR fixses all. Also this change makes empty grenade craftable. 
