### PR TITLE
Remove steel duplication

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1632,6 +1632,20 @@ RecyclingHelper.replaceShaped("gregtech:casing_steel_solid", item('gregtech:meta
     [ore('plateSteel'), ore('craftingToolWrench'), ore('plateSteel')]
 ])
 
+for (i in 0..15) {
+RecyclingHelper.removeRecyclingRecipes(item('gregtech:warning_sign', i))
+RecyclingHelper.handleRecycling(item('gregtech:warning_sign', i), [
+    metaitem('ingotSteel') * 2
+])
+}
+
+for (i in 0..8) {
+RecyclingHelper.removeRecyclingRecipes(item('gregtech:warning_sign_1', i))
+RecyclingHelper.handleRecycling(item('gregtech:warning_sign_1', i), [
+    metaitem('ingotSteel') * 2
+])
+}
+
 ASSEMBLER.recipeBuilder()
     .circuitMeta(6)
     .inputs(ore('plateSteel') * 6)


### PR DESCRIPTION
1 solid steel machine casing requires 2 steel ingots, but the warning signs are all crafted using 1 solid steel case that can then be recycled for 4 steel ingots.