### PR TITLE
Making ethane flammable

### DIFF
--- a/groovy/classes/ChangeFlags.groovy
+++ b/groovy/classes/ChangeFlags.groovy
@@ -796,6 +796,7 @@ class ChangeFlags {
         Naphtha.addFlags("flammable");
         NaturalGas.addFlags("flammable");
         Methane.addFlags("flammable");
+        Ethane.addFlags("flammable");
         Propane.addFlags("flammable");
         Butane.addFlags("flammable");
         Butadiene.addFlags("flammable");


### PR DESCRIPTION
## What
Ethane was voidable by smoke stack instead of flare stack.

## Outcome
Added the *flammable* flag to ethane.