### PR TITLE
Massive nerf to gaspunk cheese

### DIFF
--- a/config/gaspunk/gaspunk.cfg
+++ b/config/gaspunk/gaspunk.cfg
@@ -17,6 +17,10 @@ general {
     # You can specify entire armor sets by separating items with "&" in a single entry. Using "*" instead of an item id will match anything.
     # Examples: "minecraft:diamond_helmet", "minecraft:golden_helmet&*&minecraft:chainmail_leggings"
     S:otherGasMasks <
+        techguns:t3_power_helmet
+        techguns:t3_combat_helmet
+        techguns:t4_power_helmet
+        techguns:t1_scout_helmet
      >
 
     client {


### PR DESCRIPTION
Made soldier power armors, bandit masks, conscript power armor and fed command power armor immune to gas attacks

## What
<!--This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted.-->
<!--Linking an issue can be used alternatively to writing a description.-->
This PR will nerf gas punk. The fun police has identified that a common way to cheese certain structures is to use gas grenades. This angered me greatly so I removed this.

## Implementation Details
<!--Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed.-->
This system while good does not allow us to sort by meta id so we will need to define every armor piece as a separate item

## Outcome
<!--A short description of what this PR added/fixed/changed/removed.-->
<!--For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"-->
upsets cheesers, nobody else affected

## Additional Information
<!--This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of.-->
might add more stuff to here in the future idk

## Potential Compatibility Issues
<!--This section is for defining possible compatibility issues. It must be used when there item/block/material/machine changes, or recipe changes.-->
none

<!--**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**-->
## Is the steam armor going to be immune to gas as well?
Go blow up a LBB, no a LSB or even a LTB or even a LTSB
