### PR TITLE
fix: use dashes and unicode right arrows instead

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -176,19 +176,19 @@ def generate_mod_changelog():
     if changes["updates"]:
         markdown += "### Mod Updates\n"
         for update in changes["updates"]:
-            markdown += f"* {update['name']} {update['old_version']} -> {update['new_version']}\n"
+            markdown += f"- {update['name']} {update['old_version']} → {update['new_version']}\n"
         markdown += "\n"
     
     if changes["additions"]:
         markdown += "### Mod Additions\n"
         for addition in changes["additions"]:
-            markdown += f"* {addition['name']} -> {addition['version']}\n"
+            markdown += f"- {addition['name']} → {addition['version']}\n"
         markdown += "\n"
     
     if changes["removals"]:
         markdown += "### Mod Removals\n"
         for removal in changes["removals"]:
-            markdown += f"* {removal['name']}\n"
+            markdown += f"- {removal['name']}\n"
         markdown += "\n"
     
     return markdown, susy_old_version, susy_new_version


### PR DESCRIPTION
Maybe fixes the below issue:
![image](https://github.com/user-attachments/assets/29db223c-5e79-400b-9779-0e1f9ffdf172)
