### PR TITLE
Fixed diluted sodium sulfate solution distillation to not require HV

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -3732,8 +3732,8 @@ DISTILLERY.recipeBuilder()
     .fluidInputs(fluid('diluted_sodium_sulfate_solution') * 2000)
     .fluidOutputs(fluid('water') * 2000)
     .outputs(metaitem('dustSodiumSulfate') * 7)
-    .duration(30)
-    .EUt(200)
+    .duration(200)
+    .EUt(Globals.voltAmps[1])
     .buildAndRegister()
 
 // Dense steam processing


### PR DESCRIPTION
## What
The updated chromium line creates diluted sodium sulfate solution which is meant to be recycled, but the distillation recipe for that was 200 eu/t for 1.5 seconds. It didn't really make sense to limit recycling in the line to HV and higher.

## Outcome
Changed the diluted sodium sulfate solution distillation to have the same duration and eu/t as the non-diluted solution (30 eu/t for 10 seconds). Running it at MV works out because the crystallizer generates 2000L per 5 seconds.

It looks like the 200eu/t recipe was added the same time a 200eu/t batch reactor recipe was added for aluminium hydroxide (which output the solution as a byproduct). Oddly enough this commit just swaps the 200 and 30 so maybe it was a typo all along.