### PR TITLE
Add circuit to CSTR benzenesulfonic acid to fix recipe collision

### DIFF
--- a/groovy/postInit/chemistry/organic_chemistry/polymers/thermoplastics/PolyetherEtherKetoneChain.groovy
+++ b/groovy/postInit/chemistry/organic_chemistry/polymers/thermoplastics/PolyetherEtherKetoneChain.groovy
@@ -160,6 +160,7 @@ CSTR.recipeBuilder()
     .fluidInputs(fluid('sulfuric_acid') * 50)
     .fluidOutputs(fluid('benzenesulfonic_acid') * 50)
     .fluidOutputs(fluid('water') * 50)
+    .circuitMeta(2)
     .duration(5)
     .EUt(120)
     .buildAndRegister();


### PR DESCRIPTION
## What
Ethylbenzene is uncraftable in a CSTR due to a recipe collision.

## Outcome
Adds a circuit to the benzenesulfonic acid recipe.

