### PR TITLE
Fix: Acacias being breakable by hand

### DIFF
--- a/config/dropt/wood.json
+++ b/config/dropt/wood.json
@@ -5,6 +5,7 @@
         "blocks": {
           "blocks": [
             "minecraft:log:*",
+            "minecraft:log2:*",
             "biomesoplenty:log_0:*",
             "biomesoplenty:log_1:*",
             "biomesoplenty:log_2:*",


### PR DESCRIPTION
## What:
 Fixes #1621: Acacias and dark oaks were breakable by hand.
## Implementation Details:
Adds minecraft:log2 to a list of logs that do not drop when broken by hand. 
## Outcome:
Acacias and dark oaks now require an axe to break.
At least 2 people will be more happy.



