### PR TITLE
Fix: Gunpowder being craftable by hand

### DIFF
--- a/groovy/postInit/mod/ICBM.groovy
+++ b/groovy/postInit/mod/ICBM.groovy
@@ -103,6 +103,7 @@ def name_removals = [
     "icbmclassic:spikes.2",
     "icbmclassic:powder.poison",
     "icbmclassic:saltpeter_ball",
+    "icbmclassic:parts/vanilla/gunpowder",
 ]
 
 for (item in name_removals) {


### PR DESCRIPTION
## What
Fixes #1549.

## Implementation Details
Removes gunpowder recipe from ICBM Classic.

## Outcome
Gunpowder now requires a mixer to craft as in the questbook.

