### PR TITLE
Update immersiverailroading.cfg

### DIFF
--- a/config/immersiverailroading.cfg
+++ b/config/immersiverailroading.cfg
@@ -68,7 +68,7 @@ general {
         D:slopeMultiplier=0.3
         
         # Brake Multiplier: Higher numbers increase slowdown, lower numbers decrease slowdown
-        D:brakeMultiplier=10.0
+        D:brakeMultiplier=1000.0
         
         # Traction Multiplier: Higher numbers decreases wheel slip, lower numders increase wheel slip
         D:tractionMultiplier=4.0

--- a/config/immersiverailroading.cfg
+++ b/config/immersiverailroading.cfg
@@ -68,7 +68,7 @@ general {
         D:slopeMultiplier=0.7
         
         # Brake Multiplier: Higher numbers increase slowdown, lower numbers decrease slowdown
-        D:brakeMultiplier=3.0
+        D:brakeMultiplier=10.0
         
         # Traction Multiplier: Higher numbers decreases wheel slip, lower numders increase wheel slip
         D:tractionMultiplier=1.0

--- a/config/immersiverailroading.cfg
+++ b/config/immersiverailroading.cfg
@@ -71,7 +71,7 @@ general {
         D:brakeMultiplier=10.0
         
         # Traction Multiplier: Higher numbers decreases wheel slip, lower numders increase wheel slip
-        D:tractionMultiplier=1.0
+        D:tractionMultiplier=4.0
         
         # How heavy is a single block in Kg
         I:blockWeight=10

--- a/config/immersiverailroading.cfg
+++ b/config/immersiverailroading.cfg
@@ -68,7 +68,7 @@ general {
         D:slopeMultiplier=0.3
         
         # Brake Multiplier: Higher numbers increase slowdown, lower numbers decrease slowdown
-        D:brakeMultiplier=1000.0
+        D:brakeMultiplier=111.6
         
         # Traction Multiplier: Higher numbers decreases wheel slip, lower numders increase wheel slip
         D:tractionMultiplier=4.0

--- a/config/immersiverailroading.cfg
+++ b/config/immersiverailroading.cfg
@@ -65,7 +65,7 @@ general {
         B:FuelRequired=true
         
         # Slope Multiplier: Higher numbers increase slowdown, lower numbers decrease slowdown
-        D:slopeMultiplier=0.7
+        D:slopeMultiplier=0.3
         
         # Brake Multiplier: Higher numbers increase slowdown, lower numbers decrease slowdown
         D:brakeMultiplier=10.0


### PR DESCRIPTION
trains break strength is so shit that theyre basically unusable, the in game configs go up to 10 so thats what i set it to
