### PR TITLE
Diluted Ammonium Chloride Solution Stoich Distillery Fix

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -84,7 +84,7 @@ DT.recipeBuilder()
 
 DISTILLERY.recipeBuilder()
     .circuitMeta(3)
-    .fluidInputs(fluid('diluted_ammonium_chloride_solution') * 1000)
+    .fluidInputs(fluid('diluted_ammonium_chloride_solution') * 2000)
     .outputs(metaitem('dustAmmoniumChloride') * 6)
     .fluidOutputs(fluid('water') * 2000)
     .duration(120)


### PR DESCRIPTION
## What
The recipe for distilling diluted ammonium chloride solution into water and ammonium chloride gives twice as much water and ammonium chloride dust as it should when set to the third circuit.

## Outcome
I fixed the stoich of the distillery recipe by doubling required diluted ammonium chloride solution to do the recipe so that now the diluted ammonium chloride solution has yields the correct amount of products.
