### PR TITLE
Added dustwood recipe with Mortar

### DIFF
--- a/groovy/postInit/gameplay/StartingAge.groovy
+++ b/groovy/postInit/gameplay/StartingAge.groovy
@@ -33,11 +33,15 @@ crafting.replaceShapeless("gregtech:clay_ball_to_dust", metaitem('dustClay'), [
         ore('ingotClay')
 ])
 
-crafting.replaceShapeless("gregtech:log_to_pulps", metaitem('dustWood'), [
+crafting.replaceShapeless("gregtech:stick_to_smallwoodpulp", metaitem('dustSmallWood'), [
         ore('craftingToolMortar'),
-        ore('logWood')
+        ore('stickWood')
 ])
 
+crafting.replaceShapeless("gregtech:longstick_to_woodpulp", metaitem('dustWood'), [
+        ore('craftingToolMortar'),
+        ore('stickLongWood')
+])
 // 8 * compressed clay
 crafting.addShaped("gregtech:compressed_clay_8", item('gregtech:meta_item_1', 349) * 8, [
         [ore('ingotClay'), ore('ingotClay'), ore('ingotClay')],

--- a/groovy/postInit/gameplay/StartingAge.groovy
+++ b/groovy/postInit/gameplay/StartingAge.groovy
@@ -33,6 +33,11 @@ crafting.replaceShapeless("gregtech:clay_ball_to_dust", metaitem('dustClay'), [
         ore('ingotClay')
 ])
 
+crafting.replaceShapeless("gregtech:log_to_pulps", metaitem('dustWood'), [
+        ore('craftingToolMortar'),
+        ore('logWood')
+])
+
 // 8 * compressed clay
 crafting.addShaped("gregtech:compressed_clay_8", item('gregtech:meta_item_1', 349) * 8, [
         [ore('ingotClay'), ore('ingotClay'), ore('ingotClay')],


### PR DESCRIPTION
## What
I found it quite annoying that you can’t craft paper in the Stone Age, even though it’s required for arrows in one of the Stone Age quests. Considering paper existed long before steam machines, it makes no sense for paper to be gated behind steam macerator or rarely from a chopping block . Other GregTech packs include it this recipe. 

## Outcome
with the mortar you macerate wood log to one wood dust/pulp

## Additional Information
the output is suppose to be 2 wood dust, but I think it will be better if its kept at 1 per log. 