### PR TITLE
re-enable Long Distame Item Pipeline

### DIFF
--- a/config/susy/susy.cfg
+++ b/config/susy/susy.cfg
@@ -1,0 +1,9 @@
+# Configuration file
+
+general {
+    # Whether or not to disable Long-Distance Item Pipe recipes.
+    # Default: false
+    B:disableLdItemPipes=false
+}
+
+


### PR DESCRIPTION
Until automate routing and scheduling of trains is implemented, LD item pipeline should be enabled.