### PR TITLE
Use Ni(OH)2 instead of NiOOH in battery production

### DIFF
--- a/groovy/material/FirstDegreeMaterialsA.groovy
+++ b/groovy/material/FirstDegreeMaterialsA.groovy
@@ -1373,13 +1373,7 @@ class FirstDegreeMaterialsA {
 
         NickelHydroxide.setFormula("Ni(OH)2", true)
 
-        NickelOxideHydroxide = new Material.Builder(8292, SuSyUtility.susyId('nickel_oxide_hydroxide'))
-                .dust()
-                .components(Nickel, Oxygen * 3, Hydrogen * 2)
-                .colorAverage()
-                .build()
-
-        NickelOxideHydroxide.setFormula("NiO(OH)2", true)
+        // FREE ID: 8292
 
         SilverNitrateSolution = new Material.Builder(8293, SuSyUtility.susyId('silver_nitrate_solution'))
                 .liquid()

--- a/groovy/material/SuSyMaterials.groovy
+++ b/groovy/material/SuSyMaterials.groovy
@@ -1141,7 +1141,6 @@ class SuSyMaterials {
     public static Material LithiumHexafluorophosphate
     public static Material NickelHydroxide
     public static Material NickelChloride
-    public static Material NickelOxideHydroxide
     public static Material SilverNitrateSolution
     public static Material ChloroauricAcid
     public static Material SpentMoebiusElectrolyte

--- a/groovy/postInit/components/Batteries.groovy
+++ b/groovy/postInit/components/Batteries.groovy
@@ -224,9 +224,9 @@ RecyclingHelper.handleRecycling(metaitem('battery.hull.iv'),
 // Primitive LV Battery Hull
 
 crafting.addShaped('primitive_battery_hull_lv', metaitem('battery.primitivehull.lv'), [
-    [ore('plateGlass'),         metaitem('cableGtSingleTin'),   ore('plateGlass')],
-    [ore('plateRubber'),  ore('plateGlass'),              ore('plateRubber')],
-    [null,                      null,                           null]
+    [ore('plateGlass'),  metaitem('cableGtSingleTin'),   ore('plateGlass')],
+    [ore('plateRubber'), ore('plateGlass'),              ore('plateRubber')],
+    [null,               null,                           null]
 ])
 
 ASSEMBLER.recipeBuilder()
@@ -322,16 +322,6 @@ ROASTER.recipeBuilder()
         .EUt(30)
         .buildAndRegister()
 
-BR.recipeBuilder()
-        .inputs(ore('dustNickelHydroxide') * 10)
-        .fluidInputs(fluid('potassium_hydroxide_solution') * 2000)
-        .fluidInputs(fluid('chlorine') * 2000)
-        .outputs(metaitem('dustNickelOxideHydroxide') * 8)
-        .fluidOutputs(fluid('diluted_rock_salt_solution') * 4000)
-        .duration(100)
-        .EUt(30)
-        .buildAndRegister()
-
 mods.gregtech.assembler.recipeBuilder()
         .inputs(metaitem('battery.hull.hv'))
         .inputs(ore('dustCarbon') * 4)
@@ -365,7 +355,7 @@ mods.gregtech.assembler.recipeBuilder()
 mods.gregtech.assembler.recipeBuilder()
         .inputs(metaitem('battery.hull.mv'))
         .inputs(ore('dustCadmium') * 2)
-        .inputs(ore('dustNickelOxideHydroxide') * 2)
+        .inputs(ore('dustNickelHydroxide') * 5)
         .fluidInputs(fluid('potassium_hydroxide_solution') * 200)
         .outputs(metaitem('battery.re.mv.cadmium'))
         .duration(200)
@@ -375,7 +365,7 @@ mods.gregtech.assembler.recipeBuilder()
 mods.gregtech.assembler.recipeBuilder()
         .inputs(metaitem('battery.hull.hv'))
         .inputs(ore('dustCadmium') * 4)
-        .inputs(ore('dustNickelOxideHydroxide') * 4)
+        .inputs(ore('dustNickelHydroxide') * 10)
         .fluidInputs(fluid('potassium_hydroxide_solution') * 500)
         .outputs(metaitem('battery.re.hv.cadmium'))
         .duration(400)

--- a/resources/langfiles/lang/de_de.lang
+++ b/resources/langfiles/lang/de_de.lang
@@ -701,7 +701,6 @@ susy.material.lithium_hexafluorophosphate=Lithiumhexafluorophosphat
 susy.material.nickel_chloride=Nickelchlorid
 susy.material.nickel_hydroxide=Nickelhydroxid
 susy.material.dimethyl_carbonate=Dimethylcarbonat
-susy.material.nickel_oxide_hydroxide=Nickeloxidhydroxid
 susy.material.calcium_orthosilicate=Calciumorthosilikat
 susy.material.magnesium_hydroxide=Magnesiumhydroxid
 susy.material.magnesium_chloride_solution=Magnesiumchloridlösung

--- a/resources/langfiles/lang/en_pt.lang
+++ b/resources/langfiles/lang/en_pt.lang
@@ -714,7 +714,6 @@ susy.material.lithium_hexafluorophosphate=Lithium Hexafluorophosphate
 susy.material.nickel_chloride=Nickel Chloride
 susy.material.nickel_hydroxide=Nickel Hydroxide
 susy.material.dimethyl_carbonate=Dimethyl Carbonate
-susy.material.nickel_oxide_hydroxide=Nickel Oxide Hydroxide
 susy.material.calcium_orthosilicate=Calcium Orthosilicate
 susy.material.magnesium_hydroxide=Magnesium Hydroxide
 susy.material.magnesium_chloride_solution=Magnesium Chloride Solution

--- a/resources/langfiles/lang/en_us.lang
+++ b/resources/langfiles/lang/en_us.lang
@@ -723,7 +723,6 @@ susy.material.lithium_hexafluorophosphate=Lithium Hexafluorophosphate
 susy.material.nickel_chloride=Nickel Chloride
 susy.material.nickel_hydroxide=Nickel Hydroxide
 susy.material.dimethyl_carbonate=Dimethyl Carbonate
-susy.material.nickel_oxide_hydroxide=Nickel Oxide Hydroxide
 susy.material.calcium_orthosilicate=Calcium Orthosilicate
 susy.material.magnesium_hydroxide=Magnesium Hydroxide
 susy.material.magnesium_chloride_solution=Magnesium Chloride Solution

--- a/resources/langfiles/lang/pl_pl.lang
+++ b/resources/langfiles/lang/pl_pl.lang
@@ -696,7 +696,6 @@ susy.material.lithium_hexafluorophosphate=Lithium Hexafluorophosphate
 susy.material.nickel_chloride=Nickel Chloride
 susy.material.nickel_hydroxide=Nickel Hydroxide
 susy.material.dimethyl_carbonate=Dimethyl Carbonate
-susy.material.nickel_oxide_hydroxide=Nickel Oxide Hydroxide
 susy.material.calcium_orthosilicate=Calcium Orthosilicate
 susy.material.magnesium_hydroxide=Magnesium Hydroxide
 susy.material.magnesium_chloride_solution=Magnesium Chloride Solution

--- a/resources/langfiles/lang/ru_ru.lang
+++ b/resources/langfiles/lang/ru_ru.lang
@@ -687,7 +687,6 @@ susy.material.lithium_hexafluorophosphate=Литий гексафторфосф�
 susy.material.nickel_chloride=Никель хлорид
 susy.material.nickel_hydroxide=Гидроксид никеля
 susy.material.dimethyl_carbonate=Диметилкарбонат
-susy.material.nickel_oxide_hydroxide=Гидроксид оксида никеля 
 susy.material.calcium_orthosilicate=Ортосиликат кальция
 susy.material.magnesium_hydroxide=Гидроксид магния
 susy.material.magnesium_chloride_solution=Раствор хлорида магния

--- a/resources/langfiles/lang/zh_cn.lang
+++ b/resources/langfiles/lang/zh_cn.lang
@@ -708,7 +708,6 @@ susy.material.lithium_hexafluorophosphate=六氟磷酸锂
 susy.material.nickel_chloride=氯化镍
 susy.material.nickel_hydroxide=氢氧化镍
 susy.material.dimethyl_carbonate=碳酸二甲酯
-susy.material.nickel_oxide_hydroxide=二氢氧化氧镍
 susy.material.calcium_orthosilicate=正硅酸钙
 susy.material.magnesium_hydroxide=氢氧化镁
 susy.material.magnesium_chloride_solution=氯化镁溶液


### PR DESCRIPTION
NiO(OH) is unstable and it's formed inside battery when it's charging. Ni(OH)2 is used in cathodes instead.

It has no other uses, so it's removed

also it had wrong formula NiO(OH)2