### PR TITLE
Fixed input amounts of phthalic anhydride dust

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -2007,7 +2007,7 @@ MIXER.recipeBuilder()
 // 2-EAQ
 
 BR.recipeBuilder()
-    .inputs(ore("dustPhthalicAnhydride") * 13)
+    .inputs(ore("dustPhthalicAnhydride") * 15)
     .fluidInputs(fluid("ethylbenzene") * 1000)
     .fluidOutputs(fluid("two_ethylanthraquinone") * 1000)
     .fluidOutputs(fluid("water") * 1000)

--- a/groovy/postInit/chemistry/organic_chemistry/petrochemistry/Fuels.groovy
+++ b/groovy/postInit/chemistry/organic_chemistry/petrochemistry/Fuels.groovy
@@ -345,7 +345,7 @@ BR.recipeBuilder()
         .buildAndRegister();
 
     BR.recipeBuilder()
-        .inputs(ore("dustPhthalicAnhydride") * 13)
+        .inputs(ore("dustPhthalicAnhydride") * 15)
         .fluidInputs(fluid('dihexadecylamine') * 2000)
         .notConsumable(fluid('sulfuric_acid') * 50)
         .outputs(metaitem('dustDihexadecylaminePhthalateAmide'))


### PR DESCRIPTION
## What
Phthalic anhydride dust has 15 atoms but a couple places used 13 dust.

## Outcome
Fixes the inputs to make them all consistent.

