### PR TITLE
Fiery's Fixes 2

### DIFF
--- a/groovy/postInit/chemistry/organic_chemistry/Extractants.groovy
+++ b/groovy/postInit/chemistry/organic_chemistry/Extractants.groovy
@@ -450,7 +450,7 @@ import static gregtech.api.GTValues.*
         .fluidInputs(fluid('sodium_hydroxide_solution') * 1000)
         .fluidInputs(fluid('butyraldehyde') * 2000)
         .fluidOutputs(fluid('two_ethyl_two_hexenal') * 3000)
-        .fluidOutputs(fluid('diluted_sodium_hydroxide_solution') * 1000)
+        .fluidOutputs(fluid('diluted_sodium_hydroxide_solution') * 2000)
         .duration(60)
         .EUt(VA[MV])
         .buildAndRegister()

--- a/groovy/postInit/components/Photomasks.groovy
+++ b/groovy/postInit/components/Photomasks.groovy
@@ -89,7 +89,7 @@ BR.recipeBuilder()
     .buildAndRegister()
 
 CRYSTALLIZER.recipeBuilder()
-    .inputs(ore('springNichrome'))
+    .inputs(ore('springKanthal'))
     .fluidInputs(fluid('benzenediazonium_chloride_solution') * 4000)
     .outputs(metaitem('dustBenzenediazoniumChloride') * 14)
     .fluidOutputs(fluid('salt_water') * 1000)


### PR DESCRIPTION
Yes this will be the default naming convention from now.

  - Fixed the recipe for benzenediazonium chloride, which is needed for rubylith, requiring a nichrome spring since it cannot be obtained without HV energy hatches, which need rubylith.
  - Corrected mol balance for 2-Ethyl-2-hexenal so that sodium hydroxide wasn't lost
