### PR TITLE
Fiery's Fixes

### DIFF
--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/d_block/group10/PlatinumGroupChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/d_block/group10/PlatinumGroupChain.groovy
@@ -82,7 +82,7 @@ def metals = [
 
 for (metal in metals) {
     ERF.recipeBuilder()
-        .circuitMeta(1)
+        .circuitMeta(3)
         .inputs(metaitem('dust' + metal))
         .outputs(metaitem('ingot' + metal))
         .blastFurnaceTemp(2000)
@@ -91,7 +91,7 @@ for (metal in metals) {
         .buildAndRegister()
 
     ERF.recipeBuilder()
-        .circuitMeta(2)
+        .circuitMeta(4)
         .inputs(metaitem('dust' + metal))
         .fluidInputs(fluid('nitrogen') * 1000)
         .outputs(metaitem('ingot' + metal))

--- a/groovy/postInit/gameplay/FurnaceSingleblock.groovy
+++ b/groovy/postInit/gameplay/FurnaceSingleblock.groovy
@@ -42,7 +42,7 @@ def nonMetals = [
         [input: item('minecraft:stained_hardened_clay', 15), output: item('minecraft:black_glazed_terracotta')],
         [input: item('biomesoplenty:mudball'), output: item('biomesoplenty:mud_brick')],
         [input: item('biomesoplenty:mud'), output: item('minecraft:dirt')],
-        [input: metaitem('gregtechfoodoption:brick.adobe_fired'), output: metaitem('gregtechfoodoption:brick.adobe')],
+        [input: metaitem('gregtechfoodoption:brick.adobe'), output: metaitem('gregtechfoodoption:brick.adobe_fired')],
         [input: metaitem('compressed.clay'), output: item('minecraft:brick')],
         [input: metaitem('compressed.coke_clay'), output: metaitem('brick.coke')],
         [input: metaitem('compressed.fireclay'), output: metaitem('brick.fireclay')],

--- a/groovy/postInit/mod/TechGuns.groovy
+++ b/groovy/postInit/mod/TechGuns.groovy
@@ -1402,37 +1402,6 @@ WEAPONS_FACTORY.recipeBuilder()
     .EUt(VA[HV])
     .buildAndRegister();
 
-// Repair bench materials
-
-TGArmors.t1_miner_Helmet.setRepairMats(item('gregtech:meta_plate', 51), TGItems.HEAVY_CLOTH, 0.5f, 2)
-TGArmors.t1_miner_Chestplate.setRepairMats(item('gregtech:meta_plate', 51), TGItems.HEAVY_CLOTH, 0.5f, 4)
-TGArmors.t1_miner_Leggings.setRepairMats(item('gregtech:meta_plate', 51), TGItems.HEAVY_CLOTH, 0.333f, 2)
-TGArmors.t1_miner_Boots.setRepairMats(item('gregtech:meta_plate', 51), TGItems.HEAVY_CLOTH, 0.5f, 2)
-
-TGArmors.t1_combat_Helmet.setRepairMats(item('gregtech:meta_plate', 324), TGItems.HEAVY_CLOTH, 0.5f, 2)
-TGArmors.t1_combat_Chestplate.setRepairMats(item('gregtech:meta_plate', 324), TGItems.HEAVY_CLOTH, 0.5f, 4)
-TGArmors.t1_combat_Leggings.setRepairMats(item('gregtech:meta_plate', 324), TGItems.HEAVY_CLOTH, 0.333f, 3)
-TGArmors.t1_combat_Boots.setRepairMats(item('gregtech:meta_plate', 324), TGItems.HEAVY_CLOTH, 0.5f, 2)
-
-TGArmors.t2_combat_Helmet.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f, 2)
-TGArmors.t2_combat_Chestplate.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f, 4)
-TGArmors.t2_combat_Leggings.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.333f, 3)
-TGArmors.t2_combat_Boots.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f, 2)
-
-TGArmors.t2_riot_Helmet.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f, 2)
-TGArmors.t2_riot_Chestplate.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f,  4)
-TGArmors.t2_riot_Leggings.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.333f, 3)
-TGArmors.t2_riot_Boots.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15154),  0.5f, 2)
-
-TGArmors.t2_commando_Helmet.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15380), 0.5f, 2)
-TGArmors.t2_commando_Chestplate.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15380), 0.5f, 4)
-TGArmors.t2_commando_Leggings.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15380), 0.333f, 3)
-TGArmors.t2_commando_Boots.setRepairMats(item('gregtech:meta_plate', 8273), item('gregtech:meta_plate', 15380), 0.5f, 2)
-
-TGArmors.riot_shield.setRepairMat(new ItemStackOreDict("platePolycarbonate",3))
-TGArmors.ballistic_shield.setRepairMat(new ItemStackOreDict("plateBoronNitride",3))
-TGArmors.advanced_shield.setRepairMat(new ItemStackOreDict("plateUltraHighMolecularWeightPolyethylene",3))
-
 //Compressed air
 
 CANNER.recipeBuilder()


### PR DESCRIPTION
Yes the naming convention is that important

  - Fixes obtaining unusable hot platinum and hot palladium from ERF
  - Fixes the resistance furnace turning adobe bricks into mud bricks
  - Removes susyified Techgun's repair bench recipes due to causing server issues