### PR TITLE
iron armor recycling fix

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -696,6 +696,17 @@ ASSEMBLER.recipeBuilder()
     .EUt(VA[EV])
     .buildAndRegister();
 
+//Iron Armor
+
+RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_helmet'))
+RecyclingHelper.handleRecycling(item('minecraft:iron_helmet'), [ore('dustSmallIron') * 13])
+
+RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_chestplate'))
+RecyclingHelper.handleRecycling(item('minecraft:iron_chestplate'), [ore('dustSmallIron') * 21])
+
+RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_leggings'))
+RecyclingHelper.handleRecycling(item('minecraft:iron_leggings'), [ore('dustSmallIron') * 21])
+
 //Ore Recipes
 
 MACERATOR.recipeBuilder()

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -696,17 +696,6 @@ ASSEMBLER.recipeBuilder()
     .EUt(VA[EV])
     .buildAndRegister();
 
-//Iron Armor
-
-RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_helmet'))
-RecyclingHelper.handleRecycling(item('minecraft:iron_helmet'), [ore('dustSmallIron') * 13])
-
-RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_chestplate'))
-RecyclingHelper.handleRecycling(item('minecraft:iron_chestplate'), [ore('dustSmallIron') * 21])
-
-RecyclingHelper.removeRecyclingRecipes(item('minecraft:iron_leggings'))
-RecyclingHelper.handleRecycling(item('minecraft:iron_leggings'), [ore('dustSmallIron') * 21])
-
 //Ore Recipes
 
 MACERATOR.recipeBuilder()

--- a/groovy/postInit/mod/VanillaRecipes.groovy
+++ b/groovy/postInit/mod/VanillaRecipes.groovy
@@ -1,6 +1,7 @@
 import static prePostInit.Recipemaps.*
 import classes.*
 import static gregtech.api.GTValues.*
+import postInit.utils.RecyclingHelper
 
 def circuit(x) {
     return metaitem('circuit.integrated').withNbt([Configuration: x])
@@ -723,17 +724,17 @@ crafting.remove("gregtech:diamond_chestplate");
 crafting.remove("gregtech:diamond_leggings");
 crafting.remove("gregtech:diamond_boots");
 
-crafting.replaceShaped('gregtech:iron_helmet', item('minecraft:iron_helmet'), [
+RecyclingHelper.replaceShaped('gregtech:iron_helmet', item('minecraft:iron_helmet'), [
         [ore('screwIron'), ore('plateIron'), ore('screwIron')],
         [ore('plateIron'), ore('leather'), ore('plateIron')],
         [null, null, null]])
 
-crafting.replaceShaped('gregtech:iron_chestplate', item('minecraft:iron_chestplate'), [
+RecyclingHelper.replaceShaped('gregtech:iron_chestplate', item('minecraft:iron_chestplate'), [
         [ore('screwIron'), null, ore('screwIron')],
         [ore('plateIron'), ore('leather'), ore('plateIron')],
         [ore('plateIron'), ore('plateIron'), ore('plateIron')]])
 
-crafting.replaceShaped('gregtech:iron_leggings', item('minecraft:iron_leggings'), [
+RecyclingHelper.replaceShaped('gregtech:iron_leggings', item('minecraft:iron_leggings'), [
         [ore('screwIron'), ore('plateIron'), ore('screwIron')],
         [ore('plateIron'), ore('leather'), ore('plateIron')],
         [ore('plateIron'), null, ore('plateIron')]])


### PR DESCRIPTION
## What
fixes the iron helmet, chestplate, and leggings recycling recipes to reflect the susy recipes of each piece, so that iron can no longer be duplicated.

## Outcome
iron armor recycling recipes changed
