### PR TITLE
changed weapon factory shotgun rounds recipe to make more sense compared to other ammo recipes

### DIFF
--- a/groovy/material/FirstDegreeMaterialsB.groovy
+++ b/groovy/material/FirstDegreeMaterialsB.groovy
@@ -643,20 +643,6 @@ class FirstDegreeMaterialsB {
                 .build()
                 .setFormula("PbO2", true)
 
-        AluminiumAlloy6061 = new Material.Builder(8759, SuSyUtility.susyId('aluminium_alloy_6061'))
-                .ingot().liquid(new FluidBuilder().temperature(923))
-                .flags(DISABLE_DECOMPOSITION, CONTINUOUSLY_CAST)
-                .components(Aluminium * 634, Magnesium * 8, Silicon * 4, Copper * 1, Chrome * 1)
-                .colorAverage()
-                .build()
-
-        AluminiumAlloy7075 = new Material.Builder(8760, SuSyUtility.susyId('aluminium_alloy_7075'))
-                .ingot().liquid(new FluidBuilder().temperature(913))
-                .flags(DISABLE_DECOMPOSITION, CONTINUOUSLY_CAST)
-                .components(Aluminium * 678, Zinc * 17, Magnesium * 20, Copper * 4, Chrome * 1)
-                .colorAverage()
-                .build()
-
         SilverNitrate = new Material.Builder(8761, SuSyUtility.susyId('silver_nitrate'))
                 .dust()
                 .components(Silver, Nitrogen, Oxygen * 3)

--- a/groovy/postInit/mod/TechGuns.groovy
+++ b/groovy/postInit/mod/TechGuns.groovy
@@ -870,11 +870,11 @@ WEAPONS_FACTORY.recipeBuilder()
     .buildAndRegister();
 
 WEAPONS_FACTORY.recipeBuilder()
-    .inputs(ore('plateBrass') * 2)
+    .inputs(ore('plateSteel'))
     .inputs(ore('dustGunpowder'))
-    .inputs(ore('roundLead') * 3)
+    .inputs(ore('roundLead'))
     .circuitMeta(2)
-    .outputs(item('techguns:itemshared', 2) * 5)
+    .outputs(item('techguns:itemshared', 2) * 24)
     .duration(10)
     .EUt(VA[LV])
     .buildAndRegister();

--- a/groovy/postInit/mod/TechGuns.groovy
+++ b/groovy/postInit/mod/TechGuns.groovy
@@ -870,11 +870,11 @@ WEAPONS_FACTORY.recipeBuilder()
     .buildAndRegister();
 
 WEAPONS_FACTORY.recipeBuilder()
-    .inputs(ore('plateBrass') * 2)
+    .inputs(ore('plateBrass'))
     .inputs(ore('dustGunpowder'))
-    .inputs(ore('roundLead') * 3)
-    .circuitMeta(2)
-    .outputs(item('techguns:itemshared', 2) * 5)
+    .inputs(ore('roundLead'))
+    .circuitMeta(1)
+    .outputs(item('techguns:itemshared', 2) * 24)
     .duration(10)
     .EUt(VA[LV])
     .buildAndRegister();


### PR DESCRIPTION
## What
Changes the weapons factory shotgun ammo recipe to make more sense compared to its crafting table recipe and other ammo recipe

## Outcome
Shotgun ammo in weapons factory now requires 1 steel plate, 1 gunpowder, 1 lead round and outputs 24 shotgun ammo

## Additional Information
This recipe was derived from the pistol ammo recipe which had a x3 yeild from crafting table to weapons factory using same items, so i did the same with shotgun ammo