### PR TITLE
Disable stalactites generation on the moon 

### DIFF
--- a/config/cavegenerator/imports/cat/common.cave
+++ b/config/cavegenerator/imports/cat/common.cave
@@ -39,7 +39,7 @@
   # which biomes should be blacklisted
   # by generic features.
   DECORATED_BIOMES: {
-    types: [ "SNOWY", "SANDY", "JUNGLE", "OCEAN", "MUSHROOM" ]
+    types: [ "SNOWY", "SANDY", "JUNGLE", "OCEAN", "MUSHROOM", "VOID" ]
     names: [ "roofed_forest" ]
   }
   # All of the biomes where dense / lush 


### PR DESCRIPTION
## What
Changes Cavegenerator config to disable it.

## Implementation Details
Adds void biomes (Lunar highlands and Lunar maria) to decoration blacklist

## Outcome
Fixed stalactites on the moon

## Potential Compatibility Issues
Maybe some other biome is void?
