### PR TITLE
Add BiomeTweaker 

### DIFF
--- a/config/BiomeTweaker/BiomeTweaker.cfg
+++ b/config/BiomeTweaker/BiomeTweaker.cfg
@@ -1,0 +1,18 @@
+# Configuration file
+
+"output files" {
+    # If true, BiomeTweaker will not generate any output files. [default: false]
+    B:"Disable Output Files"=false
+
+    # If true, BiomeTweaker will generate separate files for each item when creating the status report. [default: true]
+    B:"Output Seperate Files"=true
+}
+
+
+scripting {
+    # A list of script files to include that are not in the scripts folder. An example script file is created along with this configuration file. [default: ]
+    S:"Script Files" <
+     >
+}
+
+

--- a/config/BiomeTweaker/scripts/RTG.cfg
+++ b/config/BiomeTweaker/scripts/RTG.cfg
@@ -1,0 +1,393 @@
+###########################################################################
+# Vanilla biomes
+# Each vanilla biome has its own variable, should you need to reference it.
+###########################################################################
+
+vanillaOcean                    = forBiomes("minecraft:ocean")
+vanillaPlains                   = forBiomes("minecraft:plains")
+vanillaDesert                   = forBiomes("minecraft:desert")
+vanillaExtremeHills             = forBiomes("minecraft:extreme_hills")
+vanillaForest                   = forBiomes("minecraft:forest")
+vanillaTaiga                    = forBiomes("minecraft:taiga")
+vanillaSwampland                = forBiomes("minecraft:swampland")
+vanillaRiver                    = forBiomes("minecraft:river")
+vanillaHell                     = forBiomes("minecraft:hell")
+vanillaTheEnd                   = forBiomes("minecraft:sky")
+vanillaFrozenOcean              = forBiomes("minecraft:frozen_ocean")
+vanillaFrozenRiver              = forBiomes("minecraft:frozen_river")
+vanillaIcePlains                = forBiomes("minecraft:ice_flats")
+vanillaIceMountains             = forBiomes("minecraft:ice_mountains")
+vanillaMushroomIsland           = forBiomes("minecraft:mushroom_island")
+vanillaMushroomIslandShore      = forBiomes("minecraft:mushroom_island_shore")
+vanillaBeach                    = forBiomes("minecraft:beaches")
+vanillaDesertHills              = forBiomes("minecraft:desert_hills")
+vanillaForestHills              = forBiomes("minecraft:forest_hills")
+vanillaTaigaHills               = forBiomes("minecraft:taiga_hills")
+vanillaExtremeHillsEdge         = forBiomes("minecraft:smaller_extreme_hills")
+vanillaJungle                   = forBiomes("minecraft:jungle")
+vanillaJungleHills              = forBiomes("minecraft:jungle_hills")
+vanillaJungleEdge               = forBiomes("minecraft:jungle_edge")
+vanillaDeepOcean                = forBiomes("minecraft:deep_ocean")
+vanillaStoneBeach               = forBiomes("minecraft:stone_beach")
+vanillaColdBeach                = forBiomes("minecraft:cold_beach")
+vanillaBirchForest              = forBiomes("minecraft:birch_forest")
+vanillaBirchForestHills         = forBiomes("minecraft:birch_forest_hills")
+vanillaRoofedForest             = forBiomes("minecraft:roofed_forest")
+vanillaColdTaiga                = forBiomes("minecraft:taiga_cold")
+vanillaColdTaigaHills           = forBiomes("minecraft:taiga_cold_hills")
+vanillaMegaTaiga                = forBiomes("minecraft:redwood_taiga")
+vanillaMegaTaigaHills           = forBiomes("minecraft:redwood_taiga_hills")
+vanillaExtremeHillsPlus         = forBiomes("minecraft:extreme_hills_with_trees")
+vanillaSavanna                  = forBiomes("minecraft:savanna")
+vanillaSavannaPlateau           = forBiomes("minecraft:savanna_rock")
+vanillaMesa                     = forBiomes("minecraft:mesa")
+vanillaMesaPlateauF             = forBiomes("minecraft:mesa_rock")
+vanillaMesaPlateau              = forBiomes("minecraft:mesa_clear_rock")
+vanillaTheVoid                  = forBiomes("minecraft:void")
+vanillaSunflowerPlains          = forBiomes("minecraft:mutated_plains")
+vanillaDesertM                  = forBiomes("minecraft:mutated_desert")
+vanillaExtremeHillsM            = forBiomes("minecraft:mutated_extreme_hills")
+vanillaFlowerForest             = forBiomes("minecraft:mutated_forest")
+vanillaTaigaM                   = forBiomes("minecraft:mutated_taiga")
+vanillaSwamplandM               = forBiomes("minecraft:mutated_swampland")
+vanillaIcePlainsSpikes          = forBiomes("minecraft:mutated_ice_flats")
+vanillaJungleM                  = forBiomes("minecraft:mutated_jungle")
+vanillaJungleEdgeM              = forBiomes("minecraft:mutated_jungle_edge")
+vanillaBirchForestM             = forBiomes("minecraft:mutated_birch_forest")
+vanillaBirchForestHillsM        = forBiomes("minecraft:mutated_birch_forest_hills")
+vanillaRoofedForestM            = forBiomes("minecraft:mutated_roofed_forest")
+vanillaColdTaigaM               = forBiomes("minecraft:mutated_taiga_cold")
+vanillaMegaSpruceTaiga          = forBiomes("minecraft:mutated_redwood_taiga")
+vanillaRedwoodTaigaHills        = forBiomes("minecraft:mutated_redwood_taiga_hills")
+vanillaExtremeHillsPlusM        = forBiomes("minecraft:mutated_extreme_hills_with_trees")
+vanillaSavannaM                 = forBiomes("minecraft:mutated_savanna")
+vanillaSavannaPlateauM          = forBiomes("minecraft:mutated_savanna_rock")
+vanillaMesaBryce                = forBiomes("minecraft:mutated_mesa")
+vanillaMesaPlateauFM            = forBiomes("minecraft:mutated_mesa_rock")
+vanillaMesaPlateauM             = forBiomes("minecraft:mutated_mesa_clear_rock")
+
+###########################################################################
+# BOP biomes
+# Each BOP biome has its own variable, should you need to reference it.
+###########################################################################
+
+bopGravelBeach                  = forBiomes("biomesoplenty:gravel_beach")
+bopWhiteBeach                   = forBiomes("biomesoplenty:white_beach")
+bopOriginBeach                  = forBiomes("biomesoplenty:origin_beach")
+bopAlps                         = forBiomes("biomesoplenty:alps")
+bopBambooForest                 = forBiomes("biomesoplenty:bamboo_forest")
+bopBayou                        = forBiomes("biomesoplenty:bayou")
+bopBog                          = forBiomes("biomesoplenty:bog")
+bopBorealForest                 = forBiomes("biomesoplenty:boreal_forest")
+bopBrushland                    = forBiomes("biomesoplenty:brushland")
+bopChaparral                    = forBiomes("biomesoplenty:chaparral")
+bopCherryBlossomGrove           = forBiomes("biomesoplenty:cherry_blossom_grove")
+bopColdDesert                   = forBiomes("biomesoplenty:cold_desert")
+bopConiferousForest             = forBiomes("biomesoplenty:coniferous_forest")
+bopCrag                         = forBiomes("biomesoplenty:crag")
+bopDeadForest                   = forBiomes("biomesoplenty:dead_forest")
+bopDeadSwamp                    = forBiomes("biomesoplenty:dead_swamp")
+bopEucalyptusForest             = forBiomes("biomesoplenty:eucalyptus_forest")
+bopFen                          = forBiomes("biomesoplenty:fen")
+bopFlowerField                  = forBiomes("biomesoplenty:flower_field")
+bopGrassland                    = forBiomes("biomesoplenty:grassland")
+bopGrove                        = forBiomes("biomesoplenty:grove")
+bopHighland                     = forBiomes("biomesoplenty:highland")
+bopLandOfLakes                  = forBiomes("biomesoplenty:land_of_lakes")
+bopLavenderFields               = forBiomes("biomesoplenty:lavender_fields")
+bopLushDesert                   = forBiomes("biomesoplenty:lush_desert")
+bopLushSwamp                    = forBiomes("biomesoplenty:lush_swamp")
+bopMangrove                     = forBiomes("biomesoplenty:mangrove")
+bopMapleWoods                   = forBiomes("biomesoplenty:maple_woods")
+bopMarsh                        = forBiomes("biomesoplenty:marsh")
+bopMeadow                       = forBiomes("biomesoplenty:meadow")
+bopMoor                         = forBiomes("biomesoplenty:moor")
+bopMountain                     = forBiomes("biomesoplenty:mountain")
+bopMysticGrove                  = forBiomes("biomesoplenty:mystic_grove")
+bopOminousWoods                 = forBiomes("biomesoplenty:ominous_woods")
+bopOrchard                      = forBiomes("biomesoplenty:orchard")
+bopOutback                      = forBiomes("biomesoplenty:outback")
+bopOvergrownCliffs              = forBiomes("biomesoplenty:overgrown_cliffs")
+bopPrairie                      = forBiomes("biomesoplenty:prairie")
+bopQuagmire                     = forBiomes("biomesoplenty:quagmire")
+bopRainforest                   = forBiomes("biomesoplenty:rainforest")
+bopRedwoodForest                = forBiomes("biomesoplenty:redwood_forest")
+bopSacredSprings                = forBiomes("biomesoplenty:sacred_springs")
+bopSeasonalForest               = forBiomes("biomesoplenty:seasonal_forest")
+bopShield                       = forBiomes("biomesoplenty:shield")
+bopShrubland                    = forBiomes("biomesoplenty:shrubland")
+bopSnowyConiferousForest        = forBiomes("biomesoplenty:snowy_coniferous_forest")
+bopSnowyForest                  = forBiomes("biomesoplenty:snowy_forest")
+bopSteppe                       = forBiomes("biomesoplenty:steppe")
+bopTemperateRainforest          = forBiomes("biomesoplenty:temperate_rainforest")
+bopTropicalRainforest           = forBiomes("biomesoplenty:tropical_rainforest")
+bopTundra                       = forBiomes("biomesoplenty:tundra")
+bopWasteland                    = forBiomes("biomesoplenty:wasteland")
+bopWetland                      = forBiomes("biomesoplenty:wetland")
+bopWoodland                     = forBiomes("biomesoplenty:woodland")
+bopXericShrubland               = forBiomes("biomesoplenty:xeric_shrubland")
+bopAlpsFoothills                = forBiomes("biomesoplenty:alps_foothills")
+bopMountainFoothills            = forBiomes("biomesoplenty:mountain_foothills")
+bopPasture                      = forBiomes("biomesoplenty:pasture")
+bopGlacier                      = forBiomes("biomesoplenty:glacier")
+bopOasis                        = forBiomes("biomesoplenty:oasis")
+bopCoralReef                    = forBiomes("biomesoplenty:coral_reef")
+bopKelpForest                   = forBiomes("biomesoplenty:kelp_forest")
+bopOriginIsland                 = forBiomes("biomesoplenty:origin_island")
+bopTropicalIsland               = forBiomes("biomesoplenty:tropical_island")
+bopVolcanicIsland               = forBiomes("biomesoplenty:volcanic_island")
+bopFlowerIsland                 = forBiomes("biomesoplenty:flower_island")
+bopCorruptedSands               = forBiomes("biomesoplenty:corrupted_sands")
+bopFungiForest                  = forBiomes("biomesoplenty:fungi_forest")
+bopPhantasmagoricInferno        = forBiomes("biomesoplenty:phantasmagoric_inferno")
+bopUndergarden                  = forBiomes("biomesoplenty:undergarden")
+bopVisceralHeap                 = forBiomes("biomesoplenty:visceral_heap")
+
+###########################################################################
+# Nether biomes
+# This variable should contain all Nether biomes.
+###########################################################################
+
+netherBiomes                    = forBiomes(vanillaHell, bopCorruptedSands, bopFungiForest, bopPhantasmagoricInferno, bopUndergarden, bopVisceralHeap)
+
+###########################################################################
+# End biomes
+# This variable should contain all End biomes.
+###########################################################################
+
+endBiomes                       = forBiomes(vanillaTheEnd)
+
+###########################################################################
+# Void biomes
+# This variable should contain all Void biomes.
+###########################################################################
+
+voidBiomes                      = forBiomes(vanillaTheVoid)
+
+###########################################################################
+# Overworld biomes
+# This variable should contain all Overworld biomes.
+###########################################################################
+
+overworldBiomes                 = forAllBiomesExcept(netherBiomes, endBiomes, voidBiomes)
+
+###########################################################################
+# Ocean biomes
+# This variable should contain all oceanic biomes.
+###########################################################################
+
+oceanBiomes                     = forBiomes(vanillaOcean, vanillaDeepOcean, bopCoralReef, bopKelpForest)
+
+###########################################################################
+# Land biomes
+# This variable should contain all land biomes.
+###########################################################################
+
+landBiomes                      = forAllBiomesExcept(oceanBiomes, netherBiomes, endBiomes, voidBiomes)
+
+###########################################################################
+# Icy overworld biomes
+# This variable should contain all ICY overworld biomes.
+###########################################################################
+
+vanillaIcyOverworldBiomes       = forBiomes(vanillaIcePlains, vanillaIceMountains, vanillaColdBeach, vanillaColdTaiga, vanillaColdTaigaHills, vanillaIcePlainsSpikes, vanillaColdTaigaM)
+bopIcyOverworldBiomes           = forBiomes(bopAlps, bopAlpsFoothills, bopColdDesert, bopSnowyConiferousForest, bopSnowyForest, bopGlacier)
+
+###########################################################################
+# Cool overworld biomes
+# This variable should contain all COOL overworld biomes.
+###########################################################################
+
+vanillaCoolOverworldBiomes      = forBiomes(vanillaOcean, vanillaExtremeHills, vanillaTaiga, vanillaTaigaHills, vanillaDeepOcean, vanillaStoneBeach, vanillaMegaTaiga, vanillaMegaTaigaHills, vanillaExtremeHillsPlus, vanillaExtremeHillsM, vanillaTaigaM, vanillaMegaSpruceTaiga, vanillaRedwoodTaigaHills, vanillaExtremeHillsPlusM)
+bopCoolOverworldBiomes          = forBiomes(bopGravelBeach, bopMapleWoods, bopMountain, bopTundra, bopMountainFoothills)
+
+###########################################################################
+# Warm overworld biomes
+# This variable should contain all WARM overworld biomes.
+###########################################################################
+
+vanillaWarmOverworldBiomes      = forAllBiomesExcept(vanillaPlains, vanillaForest, vanillaSwampland, vanillaMushroomIsland, vanillaMushroomIslandShore, vanillaBeach, vanillaForestHills, vanillaJungle, vanillaJungleHills, vanillaJungleEdge, vanillaBirchForest, vanillaBirchForestHills, vanillaRoofedForest, vanillaSunflowerPlains, vanillaFlowerForest, vanillaSwamplandM, vanillaJungleM, vanillaJungleEdgeM, vanillaBirchForestM, vanillaBirchForestHillsM, vanillaRoofedForestM)
+bopWarmOverworldBiomes          = forBiomes(bopBayou, bopBog, bopBorealForest, bopChaparral, bopCherryBlossomGrove, bopConiferousForest, bopCrag, bopDeadForest, bopDeadSwamp, bopEucalyptusForest, bopFen, bopFlowerField, bopGrassland, bopGrove, bopHighland, bopLandOfLakes, bopLavenderFields, bopLushSwamp, bopMarsh, bopMeadow, bopMoor, bopMysticGrove, bopOminousWoods, bopOrchard, bopOvergrownCliffs, bopPasture, bopPrairie, bopQuagmire, bopRainforest, bopRedwoodForest, bopSacredSprings, bopSeasonalForest, bopShield, bopShrubland, bopSteppe, bopTemperateRainforest, bopWasteland, bopWetland, bopWoodland, bopXericShrubland, bopCoralReef, bopKelpForest, bopMangrove, bopOriginBeach, bopOriginIsland, bopWhiteBeach, bopVolcanicIsland, bopFlowerIsland)
+
+###########################################################################
+# Desert overworld biomes
+# This variable should contain all DESERT overworld biomes.
+###########################################################################
+
+vanillaDesertOverworldBiomes    = forBiomes(vanillaDesert, vanillaDesertHills, vanillaSavanna, vanillaSavannaPlateau, vanillaMesa, vanillaMesaPlateauF, vanillaMesaPlateau, vanillaDesertM, vanillaSavannaM, vanillaSavannaPlateauM, vanillaMesaBryce, vanillaMesaPlateauFM, vanillaMesaPlateauM)
+bopDesertOverworldBiomes        = forBiomes(bopBambooForest, bopBrushland, bopLushDesert, bopOutback, bopTropicalRainforest, bopOasis, bopTropicalIsland)
+
+###########################################################################
+# Add all Overworld biomes to the biome pool with a default weight of 1.
+# This needs to appear BEFORE biome weights are set.
+###########################################################################
+
+vanillaIcyOverworldBiomes.addToGeneration("ICY", 1)
+vanillaCoolOverworldBiomes.addToGeneration("COOL", 1)
+vanillaWarmOverworldBiomes.addToGeneration("WARM", 1)
+vanillaDesertOverworldBiomes.addToGeneration("DESERT", 1)
+
+bopIcyOverworldBiomes.addToGeneration("ICY", 1)
+bopCoolOverworldBiomes.addToGeneration("COOL", 1)
+bopWarmOverworldBiomes.addToGeneration("WARM", 1)
+bopDesertOverworldBiomes.addToGeneration("DESERT", 1)
+
+###########################################################################
+# Biome weights
+# Controls how frequently biomes are generated.
+# You may change the weights to whatever you want.
+# Weights must be non-negative integers.
+###########################################################################
+
+vanillaBeach.set("genWeight", 1)
+vanillaBirchForest.set("genWeight", 10)
+vanillaBirchForestHills.set("genWeight", 8)
+vanillaBirchForestHillsM.set("genWeight", 4)
+vanillaBirchForestM.set("genWeight", 4)
+vanillaColdBeach.set("genWeight", 1)
+vanillaColdTaiga.set("genWeight", 10)
+vanillaColdTaigaHills.set("genWeight", 8)
+vanillaColdTaigaM.set("genWeight", 4)
+vanillaDeepOcean.set("genWeight", 2)
+vanillaDesert.set("genWeight", 10)
+vanillaDesertHills.set("genWeight", 8)
+vanillaDesertM.set("genWeight", 4)
+vanillaExtremeHills.set("genWeight", 10)
+vanillaExtremeHillsM.set("genWeight", 4)
+vanillaExtremeHillsPlus.set("genWeight", 4)
+vanillaExtremeHillsPlusM.set("genWeight", 2)
+vanillaFlowerForest.set("genWeight", 4)
+vanillaForest.set("genWeight", 10)
+vanillaForestHills.set("genWeight", 8)
+vanillaIceMountains.set("genWeight", 2)
+vanillaIcePlains.set("genWeight", 10)
+vanillaIcePlainsSpikes.set("genWeight", 1)
+vanillaJungle.set("genWeight", 10)
+vanillaJungleEdge.set("genWeight", 4)
+vanillaJungleEdgeM.set("genWeight", 2)
+vanillaJungleHills.set("genWeight", 8)
+vanillaJungleM.set("genWeight", 4)
+vanillaMegaSpruceTaiga.set("genWeight", 4)
+vanillaMegaTaiga.set("genWeight", 10)
+vanillaMegaTaigaHills.set("genWeight", 8)
+vanillaMesa.set("genWeight", 1)
+vanillaMesaBryce.set("genWeight", 1)
+vanillaMesaPlateau.set("genWeight", 1)
+vanillaMesaPlateauF.set("genWeight", 1)
+vanillaMesaPlateauFM.set("genWeight", 1)
+vanillaMesaPlateauM.set("genWeight", 1)
+vanillaMushroomIsland.set("genWeight", 1)
+vanillaMushroomIslandShore.set("genWeight", 1)
+vanillaOcean.set("genWeight", 2)
+vanillaPlains.set("genWeight", 10)
+vanillaRedwoodTaigaHills.set("genWeight", 4)
+vanillaRoofedForest.set("genWeight", 8)
+vanillaRoofedForestM.set("genWeight", 4)
+vanillaSavanna.set("genWeight", 10)
+vanillaSavannaM.set("genWeight", 4)
+vanillaSavannaPlateau.set("genWeight", 6)
+vanillaSavannaPlateauM.set("genWeight", 2)
+vanillaStoneBeach.set("genWeight", 1)
+vanillaSunflowerPlains.set("genWeight", 4)
+vanillaSwampland.set("genWeight", 10)
+vanillaSwamplandM.set("genWeight", 4)
+vanillaTaiga.set("genWeight", 10)
+vanillaTaigaHills.set("genWeight", 8)
+vanillaTaigaM.set("genWeight", 4)
+
+bopGravelBeach.set("genWeight", 5)
+bopWhiteBeach.set("genWeight", 5)
+bopOriginBeach.set("genWeight", 5)
+bopAlps.set("genWeight", 5)
+bopBambooForest.set("genWeight", 5)
+bopBayou.set("genWeight", 5)
+bopBog.set("genWeight", 5)
+bopBorealForest.set("genWeight", 5)
+bopBrushland.set("genWeight", 5)
+bopChaparral.set("genWeight", 5)
+bopCherryBlossomGrove.set("genWeight", 5)
+bopColdDesert.set("genWeight", 5)
+bopConiferousForest.set("genWeight", 5)
+bopCrag.set("genWeight", 5)
+bopDeadForest.set("genWeight", 5)
+bopDeadSwamp.set("genWeight", 5)
+bopEucalyptusForest.set("genWeight", 5)
+bopFen.set("genWeight", 5)
+bopFlowerField.set("genWeight", 5)
+bopGrassland.set("genWeight", 5)
+bopGrove.set("genWeight", 5)
+bopHighland.set("genWeight", 5)
+bopLandOfLakes.set("genWeight", 5)
+bopLavenderFields.set("genWeight", 5)
+bopLushDesert.set("genWeight", 5)
+bopLushSwamp.set("genWeight", 5)
+bopMangrove.set("genWeight", 5)
+bopMapleWoods.set("genWeight", 5)
+bopMarsh.set("genWeight", 5)
+bopMeadow.set("genWeight", 5)
+bopMoor.set("genWeight", 5)
+bopMountain.set("genWeight", 5)
+bopMysticGrove.set("genWeight", 5)
+bopOminousWoods.set("genWeight", 5)
+bopOrchard.set("genWeight", 5)
+bopOutback.set("genWeight", 5)
+bopOvergrownCliffs.set("genWeight", 5)
+bopPrairie.set("genWeight", 5)
+bopQuagmire.set("genWeight", 5)
+bopRainforest.set("genWeight", 5)
+bopRedwoodForest.set("genWeight", 5)
+bopSacredSprings.set("genWeight", 5)
+bopSeasonalForest.set("genWeight", 5)
+bopShield.set("genWeight", 5)
+bopShrubland.set("genWeight", 5)
+bopSnowyConiferousForest.set("genWeight", 5)
+bopSnowyForest.set("genWeight", 5)
+bopSteppe.set("genWeight", 5)
+bopTemperateRainforest.set("genWeight", 5)
+bopTropicalRainforest.set("genWeight", 5)
+bopTundra.set("genWeight", 5)
+bopWasteland.set("genWeight", 5)
+bopWetland.set("genWeight", 5)
+bopWoodland.set("genWeight", 5)
+bopXericShrubland.set("genWeight", 5)
+bopAlpsFoothills.set("genWeight", 5)
+bopMountainFoothills.set("genWeight", 5)
+bopPasture.set("genWeight", 5)
+bopGlacier.set("genWeight", 5)
+bopOasis.set("genWeight", 5)
+bopCoralReef.set("genWeight", 5)
+bopKelpForest.set("genWeight", 5)
+bopOriginIsland.set("genWeight", 5)
+bopTropicalIsland.set("genWeight", 5)
+bopVolcanicIsland.set("genWeight", 5)
+bopFlowerIsland.set("genWeight", 5)
+
+###########################################################################
+# Set the biome size for the "Realistic" world type
+# Default is 4; Large Biomes is 6
+###########################################################################
+
+Tweaker.setAverageBiomeSize("RTG", 4)
+
+###########################################################################
+# Set the biomes that players can spawn in
+# By default, players may spawn in any land biome.
+# You may use any of the variables above to set spawn biomes.
+# For example:
+# vanillaFlowerForest.set("isSpawnBiome", true)
+# overworldBiomes.set("isSpawnBiome", true)
+# vanillaIcyOverworldBiomes.set("isSpawnBiome", false)
+###########################################################################
+
+oceanBiomes.set("isSpawnBiome", false)
+landBiomes.set("isSpawnBiome", true)
+
+###########################################################################
+# Remove biomes from generation
+# River biomes must be removed here, but they will still generate in-game.
+###########################################################################
+
+vanillaExtremeHillsEdge.remove()
+vanillaFrozenOcean.remove()
+vanillaRiver.remove()
+vanillaFrozenRiver.remove()

--- a/mods/biometweaker.pw.toml
+++ b/mods/biometweaker.pw.toml
@@ -1,0 +1,13 @@
+name = "BiomeTweaker"
+filename = "BiomeTweaker-1.12.2-3.2.369.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "4f85402caa88c73794e8dc050386313f0a4c9ad5"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 3112142
+project-id = 228895


### PR DESCRIPTION
Fixes issue with BOP biomes not spawning. This is due to the RTG mod not natively supporting BOP and instead requiring the use of BiomeTweaker or Geographicraft, the latter of which was recently removed due to preventing worlds from loading on the CF launcher. For reference: https://github.com/Team-RTG/Realistic-Terrain-Generation/issues/1324.


