### PR TITLE
Move scattered oredict definitions into oreDict.groovy

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -1115,8 +1115,6 @@ REACTION_FURNACE.recipeBuilder()
     .EUt(VA[HV])
     .buildAndRegister()
 
-oreDict.add('dyeWhite', metaitem('dustTitaniumDioxide'))
-
 // Butyraldehyde
 
 REACTION_FURNACE.recipeBuilder()

--- a/groovy/postInit/chemistry/inorganic_chemistry/Magnets.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/Magnets.groovy
@@ -28,10 +28,6 @@ def steel_magnetic_rod_ingredients = [
     [null, null, null]
 ]
 
-oreDict.add('electrolyteFruit', metaitem('gregtechfoodoption:food.lime'))
-oreDict.add('electrolyteFruit', metaitem('gregtechfoodoption:food.lemon'))
-oreDict.add('electrolyteFruit', metaitem('gregtechfoodoption:food.orange'))
-
 crafting.removeByOutput(metaitem('stickIronMagnetic')) 
 furnace.add(metaitem('stickIron'), metaitem('hot_iron_rod'))
 furnace.add(metaitem('plateSteel'), metaitem('hot_steel_plate'))

--- a/groovy/postInit/chemistry/inorganic_chemistry/WaterPurificationChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/WaterPurificationChain.groovy
@@ -8,10 +8,6 @@ import gregtech.api.unification.stack.UnificationEntry
 // Salt * 2
 mods.gregtech.centrifuge.removeByInput(30, null, [fluid('salt_water') * 1000])
 
-oreDict.add('dustFlocculant', metaitem('dustPotassiumAlum'))
-oreDict.add('dustFlocculant', metaitem('dustSodiumAlum'))
-oreDict.add('dustFlocculant', metaitem('dustAluminiumSulfate'))
-
 // Wastewater treatment
 FLUID_HEATER.recipeBuilder()
     .fluidInputs(fluid('wastewater') * 1000)

--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/p_block/group14/GermaniumChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/p_block/group14/GermaniumChain.groovy
@@ -15,9 +15,6 @@ CHEMICAL_BATH.recipeBuilder()
 
 // Zinc hydrometallurgy route (primitive)
 
-oreDict.add('dustZincResidues', metaitem('dustZincHydrochloricLeachResidue'))
-oreDict.add('dustZincResidues', metaitem('dustZincLeachResidue'))
-
 carbons = new ItemStack[]{
         metaitem('dustCarbon'),
         metaitem('dustHighPurityCarbon'),

--- a/groovy/postInit/materials/polymers/thermoplastics/PolyesterChain.groovy
+++ b/groovy/postInit/materials/polymers/thermoplastics/PolyesterChain.groovy
@@ -44,4 +44,3 @@ EXTRUDER.recipeBuilder()
     .duration(10)
     .buildAndRegister()
 
-oreDict.add('foilMylar', metaitem('mylar'))

--- a/groovy/postInit/mod/Pyrotech.groovy
+++ b/groovy/postInit/mod/Pyrotech.groovy
@@ -626,11 +626,6 @@ RecyclingHelper.replaceShapeless("pyrotech:tech/machine/cog_iron", item('pyrotec
 RecyclingHelper.replaceShapeless("pyrotech:tech/machine/cog_gold", item('pyrotech:cog_gold'), [metaitem('gearGold')])
 RecyclingHelper.replaceShapeless("pyrotech:tech/machine/cog_diamond", item('pyrotech:cog_diamond'), [metaitem('gearDiamond')])
 
-oreDict.add("gearStone", item('pyrotech:cog_stone'))
-oreDict.add("gearIron", item('pyrotech:cog_iron'))
-oreDict.add("gearGold", item('pyrotech:cog_gold'))
-oreDict.add("gearDiamond", item('pyrotech:cog_diamond'))
-
 crafting.addShapeless("susy:cog_stone_to_gear", metaitem('gearStone'), [item('pyrotech:cog_stone')])
 crafting.addShapeless("susy:cog_iron_to_gear", metaitem('gearIron'), [item('pyrotech:cog_iron')])
 crafting.addShapeless("susy:cog_gold_to_gear", metaitem('gearGold'), [item('pyrotech:cog_gold')])

--- a/groovy/prePostInit/oreDict.groovy
+++ b/groovy/prePostInit/oreDict.groovy
@@ -85,6 +85,7 @@ ore('dyeYellow').add(metaitem('dustLeadChromate'))
 ore('dyeGreen').add(metaitem('dustMalachite'))
 ore('dyeBlue').add(metaitem('dustCobaltAluminate'))
 ore('dyeWhite').add(metaitem('dustLeadNitrate'))
+ore('dyeWhite').add(metaitem('dustTitaniumDioxide'))
 ore('dyeBlack').add(metaitem('dustCarbon'))
 ore('dyeGreen').add(metaitem('gregtechfoodoption:cupric_hydrogen_arsenite_dust'))
 
@@ -251,6 +252,20 @@ ore('blockConcrete').remove(item('susy:susy_stone_smooth:9'))
 ore('stone').remove(item('susy:susy_stone_smooth:9'))
 ore('cobblestone').remove(item('susy:susy_stone_cobble:9'))
 ore('stickStone').remove(item('pyrotech:material', 27))
+
+ore('electrolyteFruit').add(metaitem('gregtechfoodoption:food.lime'))
+ore('electrolyteFruit').add(metaitem('gregtechfoodoption:food.lemon'))
+ore('electrolyteFruit').add(metaitem('gregtechfoodoption:food.orange'))
+ore('dustZincResidues').add(metaitem('dustZincHydrochloricLeachResidue'))
+ore('dustZincResidues').add(metaitem('dustZincLeachResidue'))
+ore('dustFlocculant').add(metaitem('dustPotassiumAlum'))
+ore('dustFlocculant').add(metaitem('dustSodiumAlum'))
+ore('dustFlocculant').add(metaitem('dustAluminiumSulfate'))
+ore('foilMylar').add(metaitem('mylar'))
+ore('gearStone').add(item('pyrotech:cog_stone'))
+ore('gearIron').add(item('pyrotech:cog_iron'))
+ore('gearGold').add(item('pyrotech:cog_gold'))
+ore('gearDiamond').add(item('pyrotech:cog_diamond'))
 
 //Misc Fixes
 


### PR DESCRIPTION
## What
Fixes issues where some oredicts are used before they are defined, like the rubylith recipe missing mylar.

## Outcome
All the oreDict.add calls in postInit/ have been moved into prePostInit/oreDict.groovy and changed to ore(...).add(...) to match the style of the others.