### PR TITLE
Fixed missing preheated air recipe

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -1729,9 +1729,6 @@ MIXER.recipeBuilder()
     .duration(80)
     .buildAndRegister()
 
-// fix conflict
-mods.gregtech.fluid_heater.removeByInput(120, [metaitem('circuit.integrated').withNbt(["Configuration": 2])], [fluid('air') * 1000])
-
 DRYER.recipeBuilder()
     .fluidInputs(fluid('cellulose_acetate_solution') * 2000)
     .fluidInputs(fluid('hot_air') * 1000)


### PR DESCRIPTION
Removed a leftover removeByInput that was removing the preheated air recipe.