### PR TITLE
Make cellulose acetate mesh craftable without silicon wafers.

### DIFF
--- a/groovy/postInit/chemistry/organic_chemistry/petrochemistry/Lubricants.groovy
+++ b/groovy/postInit/chemistry/organic_chemistry/petrochemistry/Lubricants.groovy
@@ -634,7 +634,7 @@ import static gregtech.api.unification.ore.OrePrefix.dye;
         .fluidInputs(fluid('boron_trifluoride') * 10)
         .fluidOutputs(fluid('polyethylene_glycol') * 1000)
         .duration(200)
-        .EUt(240)
+        .EUt(120)
         .buildAndRegister()
 
 // Antiwear


### PR DESCRIPTION
Due to an error, ultrapure water needed cellulose acetate which needed PEG, which needed MV energy hatches. You can't make MV energy hatches without ultrapure water.
