### PR TITLE
Fix conflicting recipes

### DIFF
--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -1472,6 +1472,7 @@ DT.recipeBuilder()
 //Diethyl Ether
 
 CSTR.recipeBuilder()
+    .circuitMeta(1)
     .fluidInputs(fluid('ethanol') * 100)
     .fluidInputs(fluid('sulfuric_acid') * 50)
     .fluidOutputs(fluid('diethyl_ether_solution') * 150)


### PR DESCRIPTION
Diethyl ether solution and acidic ethyl acetate - water mixture use sulfuric acid and ethanol in their recipes. Making the mixture results in diethyl ether solution being produced. This PR adds circuit needed to make diethyl ether
