### PR TITLE
Added the Packwiz Mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1,6 +1,1 @@
-hash-format = "sha256"
 
-[[files]]
-file = "mods/keyboard-wizard.pw.toml"
-hash = "9f2991da95b34d0bfa5cc49840ea9cee54d021eeafe04d503d074429c42255d1"
-metafile = true

--- a/index.toml
+++ b/index.toml
@@ -1,0 +1,6 @@
+hash-format = "sha256"
+
+[[files]]
+file = "mods/keyboard-wizard.pw.toml"
+hash = "9f2991da95b34d0bfa5cc49840ea9cee54d021eeafe04d503d074429c42255d1"
+metafile = true

--- a/mods/keyboard-wizard.pw.toml
+++ b/mods/keyboard-wizard.pw.toml
@@ -1,0 +1,13 @@
+name = "Keyboard Wizard"
+filename = "keywizard-1.12.2-1.7.3.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "7a2b6c551a18af294db471c1966add0dd85856cc"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 2841927
+project-id = 262366

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e6639a888066b344d88186974847df2d6a0703a46a67b617035943d3f418be89"
+hash = "7dd75ca8f7b2bb3a91c87129e19d3741ca00e86ae37fc48ffc6a755d820a0718"
 
 [versions]
 forge = "14.23.5.2860"


### PR DESCRIPTION
This QoL mod adds an Overview over all Keybinds with a visual Keyboard. Makes it easier to find Keys that dont have a Conflict. 

No Problems or Conflicts found in testing. 

Here is how it looks like: 
<img width="1915" height="1020" alt="{59BBB259-8178-4EB8-B792-6482FF7E3FBD}" src="https://github.com/user-attachments/assets/77f0ba1f-ad7c-4660-a60f-e669040337cf" />


Overview works with Modifiers like Ctrl, Alt and Shift

<img width="1426" height="698" alt="{3B605B6C-C85F-408F-8B4C-045811A3A402}" src="https://github.com/user-attachments/assets/46702c51-d260-4768-b06a-bc319d1830bc" />

