### PR TITLE
add pentlandite ore to tier 2 (MV) at 40%

### DIFF
--- a/groovy/postInit/materials/metallurgy/OreSorting.groovy
+++ b/groovy/postInit/materials/metallurgy/OreSorting.groovy
@@ -2,13 +2,13 @@ import static prePostInit.Recipemaps.*
 import classes.*
 import static gregtech.api.GTValues.*
 
-log.infoMC("Running OreSorting.groovy...")
+log.infoMC('Running OreSorting.groovy...')
 
-int fluid_amount = 100;
+int fluid_amount = 100
 
 //FORMAT: ORE NAME : CHANCE (out of 10000)
 //REBALANCING MAY BE DONE AS WE GO ON
-//Divine Ray commented out unused/worthless ores 
+//Divine Ray commented out unused/worthless ores
 
 // #TODO: #967 Tweak all OreSorting.groovy recipes to be appropriate to their utility
 def orthomagmatic_tier_1 = [
@@ -19,7 +19,7 @@ def orthomagmatic_tier_1 = [
     'gregtech:ore_chalcopyrite_0' : 7500,
     'gregtech:ore_sphalerite_0' : 1000,
     'gregtech:ore_cassiterite_0' : 8000
-];
+]
 
 def orthomagmatic_tier_2 = [
     //Tier 1
@@ -31,8 +31,9 @@ def orthomagmatic_tier_2 = [
     'gregtech:ore_cassiterite_0' : 8000,
     //Tier 2
     'gregtech:ore_chromite_0' : 5000,
-    'gregtech:ore_pollucite_0' : 100
-];
+    'gregtech:ore_pollucite_0' : 100,
+    'gregtech:ore_pentlandite_0' : 4000
+]
 
 def orthomagmatic_tier_3 = [
     //Tier 1
@@ -45,8 +46,8 @@ def orthomagmatic_tier_3 = [
     //Tier 2
     'gregtech:ore_chromite_0' : 5000,
     'gregtech:ore_pollucite_0' : 100,
-    //T3
     'gregtech:ore_pentlandite_0' : 6000,
+    //T3
     'gregtech:ore_pyrochlore_0' : 2000,
     'gregtech:ore_molybdenite_0' : 1000,
     'gregtech:ore_tantalite_0' : 1000,
@@ -55,8 +56,8 @@ def orthomagmatic_tier_3 = [
     'minecraft:soul_sand' : 100,
     'gregtech:ore_vanadiferous_titanomagnetite_0' : 7500
 
-    //'gregtech:ore_thortveitite_0' : 10000,
-];
+//'gregtech:ore_thortveitite_0' : 10000,
+]
 
 def orthomagmatic_tier_4 = [
     //T1
@@ -69,8 +70,8 @@ def orthomagmatic_tier_4 = [
     //T2
     'gregtech:ore_chromite_0' : 5000,
     'gregtech:ore_pollucite_0' : 100,
+    'gregtech:ore_pentlandite_0' : 6000,
     //T3
-     'gregtech:ore_pentlandite_0' : 6000,
     'gregtech:ore_pyrochlore_0' : 2000,
     'gregtech:ore_molybdenite_0' : 1000,
     'gregtech:ore_tantalite_0' : 1000,
@@ -80,9 +81,9 @@ def orthomagmatic_tier_4 = [
     'gregtech:ore_vanadiferous_titanomagnetite_0' :7500,
     //T4
     'gregtech:ore_baddeleyite_0' : 200
-    //'susy:resource_block:8' : 10000,
-    //'gregtech:ore_thortveitite_0' : 10000,
-];
+//'susy:resource_block:8' : 10000,
+//'gregtech:ore_thortveitite_0' : 10000,
+]
 
 def metamorphic_tier_1 = [
     //T1
@@ -96,7 +97,7 @@ def metamorphic_tier_1 = [
     'gregtech:ore_realgar_0' : 7500,
     'gregtech:ore_redstone_0' : 7500,
     'gregtech:ore_tetrahedrite_0' : 9000
-];
+]
 
 def metamorphic_tier_2 = [
     //T1
@@ -113,7 +114,7 @@ def metamorphic_tier_2 = [
     //T2
     'gregtech:ore_stephanite_0' : 5000,
     'gregtech:ore_magnesite_0' : 7500
-];
+]
 
 def metamorphic_tier_3 = [
     //T1
@@ -132,7 +133,7 @@ def metamorphic_tier_3 = [
     'gregtech:ore_magnesite_0' : 7500,
     //T3
     'gregtech:ore_ilmenite_0' : 5000
-];
+]
 
 def sedimentary_tier_1 = [
     //T1
@@ -146,7 +147,7 @@ def sedimentary_tier_1 = [
     'gregtech:ore_saltpeter_0' : 5000,
     'susy:resource_block:0' : 7500,
     'susy:resource_block:12' : 5000
-];
+]
 
 def sedimentary_tier_2 = [
     //T1
@@ -162,7 +163,7 @@ def sedimentary_tier_2 = [
     'susy:resource_block:12' : 5000,
     //T2
     'gregtech:ore_magnesite_0' : 2000
-];
+]
 
 def sedimentary_tier_3 = [
     //T1
@@ -183,7 +184,7 @@ def sedimentary_tier_3 = [
     'susy:resource_block:1' : 1000,
     'gregtech:ore_celestine_0' : 500,
     'gregtech:ore_barite_0' : 2500,
-];
+]
 
 def sedimentary_tier_4 = [
     //T1
@@ -206,7 +207,7 @@ def sedimentary_tier_4 = [
     'gregtech:ore_barite_0' : 2500,
     //T4
     'gregtech:ore_carnotite_0' : 100
-];
+]
 
 def magmatic_hydrothermal_tier_1 = [
     //T1
@@ -218,7 +219,7 @@ def magmatic_hydrothermal_tier_1 = [
     'gregtech:ore_pyrite_0' : 5000,
     'gregtech:ore_redstone_0' : 2500,
     'gregtech:ore_sphalerite_0' : 7500
-];
+]
 
 def magmatic_hydrothermal_tier_2 = [
     //T1 but better
@@ -230,10 +231,10 @@ def magmatic_hydrothermal_tier_2 = [
     'gregtech:ore_pyrite_0' : 7500,
     'gregtech:ore_redstone_0' : 5000,
     'gregtech:ore_sphalerite_0' : 9000
-];
+]
 
 def magmatic_hydrothermal_tier_3 = [
-        //T1 but better
+    //T1 but better
     'gregtech:ore_cassiterite_0' : 7500,
     'gregtech:ore_chalcopyrite_0' : 5500,
     'gregtech:ore_cobaltite_0' : 5000,
@@ -246,7 +247,7 @@ def magmatic_hydrothermal_tier_3 = [
     //T3
     'gregtech:ore_scheelite_0' : 1250,
     'gregtech:ore_wolframite_0' : 1000
-];
+]
 
 def magmatic_hydrothermal_tier_4 = [
     //T1 but better
@@ -267,7 +268,7 @@ def magmatic_hydrothermal_tier_4 = [
     'gregtech:ore_bastnasite_0' : 2500,
     'gregtech:ore_pitchblende_0' : 500
 
-];
+]
 
 def hydrothermal_tier_1 = [
     //T1
@@ -284,10 +285,10 @@ def hydrothermal_tier_1 = [
     'gregtech:ore_pyrolusite_0' : 1000,
     'gregtech:ore_realgar_0' : 1500,
     'gregtech:ore_stibnite_0' : 3333
-];
+]
 
 def hydrothermal_tier_2 = [
-        //T1
+    //T1
     'gregtech:ore_acanthite_0' : 7500,
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
@@ -303,10 +304,10 @@ def hydrothermal_tier_2 = [
     'gregtech:ore_stibnite_0' : 3333,
     //T2
     'gregtech:ore_vanadinite_0' : 5000
-];
+]
 
 def hydrothermal_tier_3 = [
-        //T1
+    //T1
     'gregtech:ore_acanthite_0' : 7500,
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
@@ -325,11 +326,11 @@ def hydrothermal_tier_3 = [
     //T3
     //'gregtech:ore_witherite_0' : 2500,
     'gregtech:ore_bismuthinite_0' : 7500
-    //'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
-];
+//'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
+]
 
 def hydrothermal_tier_4 = [
-        //T1
+    //T1
     'gregtech:ore_acanthite_0' : 7500,
     'gregtech:ore_arsenopyrite_0' : 1500,
     'gregtech:ore_bornite_0' : 7500,
@@ -350,22 +351,22 @@ def hydrothermal_tier_4 = [
     'gregtech:ore_bismuthinite_0' : 7500,
     'gregtech:ore_pitchblende_0' : 1000,
     'gregtech:ore_bertrandite_0' : 1000
-    //'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
-];
+//'gregtech:ore_strontianite_0' : 10000 TODO: Fix #971
+]
 
 def alluvial_tier_1 = [
     //T1
     'gregtech:ore_cassiterite_0' : 9500,
     'susy:resource_block:10' : 100,
     'susy:resource_block:11' : 1000
-];
+]
 
 def alluvial_tier_2 = [
     //T1.2
     'gregtech:ore_cassiterite_0' : 10000,
     'susy:resource_block:10' : 200,
     'susy:resource_block:11' : 5000
-];
+]
 
 def alluvial_tier_3 = [
     //T1.3
@@ -374,7 +375,7 @@ def alluvial_tier_3 = [
     'susy:resource_block:11' : 7500,
     //T3
     'minecraft:soul_sand' : 100
-];
+]
 
 def alluvial_tier_4 = [
     //T1.4
@@ -384,16 +385,16 @@ def alluvial_tier_4 = [
     //T4
     'minecraft:soul_sand' : 100,
     'susy:resource_block:6' : 1000
-];
+]
 
 //FORMAT: BASE ROCK, WASHING FLUID, WASTE FLUID, ORE OUTPUT LISTS, STARTING VOLTAGE TIER
 
-def rock_orthomagmatic = new OreRock('rock.orthomagmatic', 'water', 'water', [orthomagmatic_tier_1, orthomagmatic_tier_2, orthomagmatic_tier_3, orthomagmatic_tier_4], LV);
-def rock_sedimentary = new OreRock('rock.sedimentary', 'water', 'water', [sedimentary_tier_1, sedimentary_tier_2, sedimentary_tier_3, sedimentary_tier_4], LV);
-def rock_metamorphic = new OreRock('rock.metamorphic', 'water', 'water', [metamorphic_tier_1, metamorphic_tier_2, metamorphic_tier_3], LV);
-def rock_magmatic_hydrothermal = new OreRock('rock.magmatic_hydrothermal', 'water', 'water', [magmatic_hydrothermal_tier_1, magmatic_hydrothermal_tier_2, magmatic_hydrothermal_tier_3, magmatic_hydrothermal_tier_4], LV);
-def rock_hydrothermal = new OreRock('rock.hydrothermal', 'water', 'water', [hydrothermal_tier_1, hydrothermal_tier_2, hydrothermal_tier_3, hydrothermal_tier_4], LV);
-def rock_alluvial = new OreRock('rock.alluvial', 'water', 'water', [alluvial_tier_1, alluvial_tier_2, alluvial_tier_3, alluvial_tier_4], LV);
+def rock_orthomagmatic = new OreRock('rock.orthomagmatic', 'water', 'water', [orthomagmatic_tier_1, orthomagmatic_tier_2, orthomagmatic_tier_3, orthomagmatic_tier_4], LV)
+def rock_sedimentary = new OreRock('rock.sedimentary', 'water', 'water', [sedimentary_tier_1, sedimentary_tier_2, sedimentary_tier_3, sedimentary_tier_4], LV)
+def rock_metamorphic = new OreRock('rock.metamorphic', 'water', 'water', [metamorphic_tier_1, metamorphic_tier_2, metamorphic_tier_3], LV)
+def rock_magmatic_hydrothermal = new OreRock('rock.magmatic_hydrothermal', 'water', 'water', [magmatic_hydrothermal_tier_1, magmatic_hydrothermal_tier_2, magmatic_hydrothermal_tier_3, magmatic_hydrothermal_tier_4], LV)
+def rock_hydrothermal = new OreRock('rock.hydrothermal', 'water', 'water', [hydrothermal_tier_1, hydrothermal_tier_2, hydrothermal_tier_3, hydrothermal_tier_4], LV)
+def rock_alluvial = new OreRock('rock.alluvial', 'water', 'water', [alluvial_tier_1, alluvial_tier_2, alluvial_tier_3, alluvial_tier_4], LV)
 
 def rocks = [
         rock_orthomagmatic,
@@ -402,24 +403,24 @@ def rocks = [
         rock_magmatic_hydrothermal,
         rock_hydrothermal,
         rock_alluvial
-];
+]
 
 for (rock in rocks) {
-    int a = 0;
+    int a = 0
     for (oreList in rock.oreLists) {
-        def recipe = ORE_SORTER.recipeBuilder();
+        def recipe = ORE_SORTER.recipeBuilder()
         recipe.circuitMeta(a + 1)
-        recipe.inputs(metaitem(rock.input_rock) * (oreList.size()));
+        recipe.inputs(metaitem(rock.input_rock) * (oreList.size()))
         for (ore in oreList) {
             if (ore.getKey() == 'gregtech:ore_coal_0') {
-                recipe.chancedOutput(item(ore.getKey()) * 2, oreList[ore.getKey()], 0);
+                recipe.chancedOutput(item(ore.getKey()) * 2, oreList[ore.getKey()], 0)
             } else {
-                recipe.chancedOutput(item(ore.getKey()), oreList[ore.getKey()], 0);
+                recipe.chancedOutput(item(ore.getKey()), oreList[ore.getKey()], 0)
             }
         }
-        recipe.duration(20);
-        recipe.EUt(VA[rock.starting_tier + a]);
-        recipe.buildAndRegister();
-        a += 1;
+        recipe.duration(20)
+        recipe.EUt(VA[rock.starting_tier + a])
+        recipe.buildAndRegister()
+        a += 1
     }
 }


### PR DESCRIPTION
## What
https://discord.com/channels/881234100504109166/1468671980956815532


## Implementation Details
Adds gregtech:ore_pentlandite_0 to the Orthomagmatic Tier 2 in OreSorting.groovy

## Outcome
Making Pentlandite accessible MV.

## Additional Information
I'm TCSlender in the discord, ping or dm if necessary.
My IDE auto format some of the code but I tested in game, it works fine.

## Potential Compatibility Issues
Should be none
