### PR TITLE
Trimethylgallium solution formula fix

### DIFF
--- a/groovy/material/OrganicChemistryMaterials.groovy
+++ b/groovy/material/OrganicChemistryMaterials.groovy
@@ -3274,7 +3274,7 @@ class OrganicChemistryMaterials {
                 .color(0x424242)
                 .build()
 
-        TrimethylGalliumSolution.setFormula('Ga(CH3)33(C6H5CH3)', true)
+        TrimethylGalliumSolution.setFormula('Ga(CH3)3(C6H5CH3)', true)
 
         TrimethylIndiumSolution = new Material.Builder(15513, SuSyUtility.susyId('trimethyl_indium_solution'))
                 .liquid()


### PR DESCRIPTION
## What
The formula for trimethylgallium solution was Ga(CH3)33(C6H5CH3). Since the formula for trimethylgallium itself is Ga(CH3)3, and the solution consists of 1 trimethylgallium and 1 toluene, this is likely an error.

## Implementation Details
delete 1 character

## Outcome
fixes literally unplayable typo

## Additional Information


## Potential Compatibility Issues
none


