### PR TITLE
Update circuitMeta value in SusyCore.groovy

### DIFF
--- a/groovy/postInit/mod/SusyCore.groovy
+++ b/groovy/postInit/mod/SusyCore.groovy
@@ -52,7 +52,7 @@ RecyclingHelper.handleRecycling(item('susy:separator_rotor') * 5,
 )
 
 ASSEMBLER.recipeBuilder()
-    .circuitMeta(9)
+    .circuitMeta(20)
     .inputs(ore('plateStainlessSteel') * 9)
     .outputs(item('susy:susy_multiblock_casing', 2))
     .duration(240)


### PR DESCRIPTION


## What
This Pull Request is to resolve a conflict between two recipes: structural packing and the recently added large stainless steel batteries. Right now, structural packing cannot be crafted.

## Implementation Details
The circuit used for structural packing has been changed to circuit 20, as there are no more recipes that use stainless steel plates with circuit 20 for the assembler.


## Outcome
Structural Packing can be crafted again


## Additional Information
<img width="1097" height="392" alt="image" src="https://github.com/user-attachments/assets/acfa3392-bebd-4d33-8db2-71da6e1be2b0" />
Img of the bug right now which is solve by the PR


