### PR TITLE
Enable PTFE rods on injection molding

### DIFF
--- a/groovy/postInit/materials/polymers/InjectionMolding.groovy
+++ b/groovy/postInit/materials/polymers/InjectionMolding.groovy
@@ -21,7 +21,7 @@ def polymers = [
         new ExtrudablePolymers('EpoxyCresolNovolacs', 120, 8, true, false, false, false, false),
 
         new ExtrudablePolymers('Polycarbonate', 480, 8, false, false, false, false, false),
-        new ExtrudablePolymers('Polytetrafluoroethylene', 480, 8, true, true, true, false, false),
+        new ExtrudablePolymers('Polytetrafluoroethylene', 480, 8, true, true, true, false, true),
         new ExtrudablePolymers('PolyethyleneTerephthalate', 480, 8, true, false, false, false, false),
         new ExtrudablePolymers('EthyleneVinylAcetate', 480, 8, false, true, true, false, false),
         new ExtrudablePolymers('SiliconeRubber', 480, 8, true, false, false, true, false),


### PR DESCRIPTION
PTFE rods have been added to the injection moulding multiblock to ensure consistency between recipes

## What
PTFE rods could not be crafted using the injection molder multiblock, which was inconsistent considering Polysulfone rods used for Polysulfone frame boxes were able to be crafted with an extruder or injection moulding. PTFE rods can only be used with a normal extruder for PTFE frame boxes, which are quite important for some multiblocks.



## Implementation Details
Change to true the groovy to let PTFE rods be crafted with the multiblock

## Outcome
PTFE rods can be crafted with an injection molder


