### PR TITLE
Added alternative recipe to clarify Sugar water

### DIFF
--- a/groovy/postInit/mod/Vanilla.groovy
+++ b/groovy/postInit/mod/Vanilla.groovy
@@ -643,6 +643,14 @@ mods.gregtech.mixer.recipeBuilder()
         .EUt(VA[ULV])
         .buildAndRegister()
 
+mods.gregtech.mixer.recipeBuilder()
+        .inputs(ore('dustSmallQuicklime'))
+        .fluidInputs(fluid('sugary_water') * 2500)
+        .fluidOutputs(fluid('clarified_sugary_water') * 2500)
+        .duration(100)
+        .EUt(VA[ULV])
+        .buildAndRegister()
+
 crafting.replaceShaped('minecraft:cobblestone_slab', item('minecraft:stone_slab', 3) * 6, [
         [null, null, null],
         [ore('cobblestone'), ore('cobblestone'), ore('cobblestone')],


### PR DESCRIPTION
## What
Currently, to get Clarified Sugary Water, you need 10kL of Sugary Water and 1 Quicklime Dust. Unfortunately, the LV Mixer cannot take 10kL of a fluid at once (max: 8kL), even if distributed over several fluid slots. This makes it impossible to gain Clarified Sugary Water - and therefore sugar - for other cooking recipes in LV.

This PR aims to fix that by adding an alternative recipe to the Mixer.


## Implementation Details
An alternative Mixer recipe, with a fourth of the inputs (Sugary Water & Quicklime Dust), outputs (Clarified Sugary Water) and stirring duration, has been added. Therefore:

### Input
10kL Sugary Water -> 2500L Sugary Water
Quicklime Dust -> Small Quicklime Dust (1/4 of a normal Quicklime Dust)

### Duration
400 ticks -> 100 ticks

### Output
10kL Clarified Sugary Water -> 2500L Clarified Water

### Energy input
Unchanged, so that running the alternative recipe 4 times in a row requires the same amount of energy as the original recipe


## Outcome
Added a way to get Clarified Sugary Water in the LV stage, that takes a fourth of the original recipes input & duration and outputs a fourth of the original recipe result

## Acknowledgments
Thanks to the discord users unittest, WideMann and Engineerboy for helping me with my first contribution