### PR TITLE
Add circuits to greenhouse

### DIFF
--- a/groovy/postInit/biology/GreenhouseChain.groovy
+++ b/groovy/postInit/biology/GreenhouseChain.groovy
@@ -802,7 +802,6 @@ def registerGreenhouseRecipeBySeed (input, output) {
 
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
-            .circuitMeta(2)
             .inputs(metaitem('fertilizer') * 2)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 24)
@@ -824,7 +823,6 @@ def registerGreenhouseRecipeNoSeed (input) {
 
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
-            .circuitMeta(2)
             .inputs(metaitem('fertilizer') * 2)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 32)
@@ -870,7 +868,6 @@ GREENHOUSE.recipeBuilder()
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:melon_seeds') * 4)
-        .circuitMeta(2)
         .inputs(metaitem('fertilizer') * 2)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:melon_seeds') * 4)
@@ -891,7 +888,6 @@ GREENHOUSE.recipeBuilder()
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:pumpkin_seeds') * 4)
-        .circuitMeta(2)
         .inputs(metaitem('fertilizer') * 2)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:pumpkin_seeds') * 4)

--- a/groovy/postInit/biology/GreenhouseChain.groovy
+++ b/groovy/postInit/biology/GreenhouseChain.groovy
@@ -792,6 +792,7 @@ seedOilSourcesMetaitem.each {seed, amount ->
 def registerGreenhouseRecipeBySeed (input, output) {
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
+            .circuitMeta(1)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 12)
             .outputs(output * 16)
@@ -801,6 +802,7 @@ def registerGreenhouseRecipeBySeed (input, output) {
 
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
+            .circuitMeta(2)
             .inputs(metaitem('fertilizer') * 2)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 24)
@@ -813,6 +815,7 @@ def registerGreenhouseRecipeBySeed (input, output) {
 def registerGreenhouseRecipeNoSeed (input) {
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
+            .circuitMeta(1)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 16)
             .duration(600)
@@ -821,6 +824,7 @@ def registerGreenhouseRecipeNoSeed (input) {
 
     GREENHOUSE.recipeBuilder()
             .notConsumable(input * 8)
+            .circuitMeta(2)
             .inputs(metaitem('fertilizer') * 2)
             .fluidInputs(fluid('water') * 2000)
             .outputs(input * 32)
@@ -856,6 +860,7 @@ registerGreenhouseRecipeNoSeed(metaitem('gregtechfoodoption:component.rice'))
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:melon_seeds') * 4)
+        .circuitMeta(1)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:melon_seeds') * 2)
         .outputs(item('minecraft:melon_block') * 4)
@@ -865,6 +870,7 @@ GREENHOUSE.recipeBuilder()
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:melon_seeds') * 4)
+        .circuitMeta(2)
         .inputs(metaitem('fertilizer') * 2)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:melon_seeds') * 4)
@@ -875,6 +881,7 @@ GREENHOUSE.recipeBuilder()
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:pumpkin_seeds') * 4)
+        .circuitMeta(1)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:pumpkin_seeds') * 2)
         .outputs(item('minecraft:pumpkin') * 4)
@@ -884,6 +891,7 @@ GREENHOUSE.recipeBuilder()
 
 GREENHOUSE.recipeBuilder()
         .notConsumable(item('minecraft:pumpkin_seeds') * 4)
+        .circuitMeta(2)
         .inputs(metaitem('fertilizer') * 2)
         .fluidInputs(fluid('water') * 2000)
         .outputs(item('minecraft:pumpkin_seeds') * 4)


### PR DESCRIPTION
## What
Greenhouse was unable to do the faster recipe with fertilizer because there wasn't a circuit designation between recipes

## Implementation Details
Changed non-fertilizer recipes to circuit 1 and fertilizer recipes to circuit 2

## Outcome
Fertilizer should work as intended now

## Additional Information
This will brick most peoples' preexisting greenhouse setups until they update the circuit, so it might be a good idea to draw attention to this change
