### PR TITLE
Hotfixery

### DIFF
--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1005,12 +1005,12 @@ ore('dustStone').each { stack ->
     def meta = stack.metadata
 
     PACKAGER.recipeBuilder()
-            .circuitMeta(1)
-            .inputs(item('gregtech:meta_dust', meta))
-            .outputs(item('gregtech:meta_dust_tiny', meta) * 9)
-            .duration(10)
-            .EUt(12)
-            .buildAndRegister()
+        .circuitMeta(1)
+        .inputs(item('gregtech:meta_dust', meta))
+        .outputs(item('gregtech:meta_dust_tiny', meta) * 9)
+        .duration(10)
+        .EUt(12)
+        .buildAndRegister()
 
     PACKAGER.recipeBuilder()
         .circuitMeta(2)

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1001,6 +1001,34 @@ PACKAGER.recipeBuilder()
     .EUt(VA[ULV])
     .buildAndRegister();
 
+PACKAGER.recipeBuilder()
+    .circuitMeta(2)
+    .inputs(metaitem('dustStone'))
+    .outputs(metaitem('dustSmallStone') * 4)
+    .duration(10)
+    .EUt(12)
+    .buildAndRegister();
+
+PACKAGER.recipeBuilder()
+    .circuitMeta(1)
+    .inputs(metaitem('dustStone'))
+    .outputs(metaitem('dustTinyStone') * 9)
+    .duration(10)
+    .EUt(12)
+    .buildAndRegister();
+
+crafting.replaceShaped("gregtech:small_dust_disassembling_stone", metaitem('dustSmallStone') * 4, [
+    [null, metaitem('dustStone'), null],
+    [null, null, null],
+    [null, null, null]
+])
+
+crafting.replaceShaped("gregtech:tiny_dust_disassembling_stone", metaitem('dustTinyStone') * 9, [
+    [metaitem('dustStone'), null, null],
+    [null, null, null],
+    [null, null, null]
+])
+
 RecyclingHelper.removeRecyclingRecipes(metaitem('fluid_filter'))
 
 RecyclingHelper.addShaped('gregtech:fluid_filter_brass', metaitem('fluid_filter'), [

--- a/groovy/postInit/mod/GregTech.groovy
+++ b/groovy/postInit/mod/GregTech.groovy
@@ -1001,21 +1001,25 @@ PACKAGER.recipeBuilder()
     .EUt(VA[ULV])
     .buildAndRegister();
 
-PACKAGER.recipeBuilder()
-    .circuitMeta(2)
-    .inputs(metaitem('dustStone'))
-    .outputs(metaitem('dustSmallStone') * 4)
-    .duration(10)
-    .EUt(12)
-    .buildAndRegister();
+ore('dustStone').each { stack ->
+    def meta = stack.metadata
 
-PACKAGER.recipeBuilder()
-    .circuitMeta(1)
-    .inputs(metaitem('dustStone'))
-    .outputs(metaitem('dustTinyStone') * 9)
-    .duration(10)
-    .EUt(12)
-    .buildAndRegister();
+    PACKAGER.recipeBuilder()
+            .circuitMeta(1)
+            .inputs(item('gregtech:meta_dust', meta))
+            .outputs(item('gregtech:meta_dust_tiny', meta) * 9)
+            .duration(10)
+            .EUt(12)
+            .buildAndRegister()
+
+    PACKAGER.recipeBuilder()
+        .circuitMeta(2)
+        .inputs(item('gregtech:meta_dust', meta))
+        .outputs(item('gregtech:meta_dust_small', meta) * 4)
+        .duration(10)
+        .EUt(12)
+        .buildAndRegister()
+}
 
 crafting.replaceShaped("gregtech:small_dust_disassembling_stone", metaitem('dustSmallStone') * 4, [
     [null, metaitem('dustStone'), null],

--- a/groovy/prePostInit/oreDict.groovy
+++ b/groovy/prePostInit/oreDict.groovy
@@ -256,12 +256,19 @@ for (i in 0..11) {
 }
 
 // Stone Dust
-for (i in 27200..27207) {
-    ore('dustStone').add(item('gregtech:meta_dust', i))
-}
 
-ore('dustStone').add(metaitem('dustQuartzite'))
-ore('dustStone').add(metaitem('dustSoapstone'))
+// Tiny Pile of Stone Dust * 9
+mods.gregtech.packer.removeByInput(12, [metaitem('dustStone'), metaitem('circuit.integrated').withNbt(['Configuration': 1])], null)
+// Small  of Stone Dust * 4
+mods.gregtech.packer.removeByInput(12, [metaitem('dustStone'), metaitem('circuit.integrated').withNbt(['Configuration': 2])], null)
+
+def dustIds = [340, 393] + (27200..27207)
+
+dustIds.each { i ->
+    ore('dustStone').add(item('gregtech:meta_dust', i))
+    mods.gregtech.packer.removeByInput(12, [item('gregtech:meta_dust', i), metaitem('circuit.integrated').withNbt(['Configuration': 1])], null)
+    mods.gregtech.packer.removeByInput(12, [item('gregtech:meta_dust', i), metaitem('circuit.integrated').withNbt(['Configuration': 2])], null)
+}
 
 // Misc Fixes
 ore('stickWood').add(item('minecraft:stick'))


### PR DESCRIPTION
Fixes issue with the susy stone dust variants turning into to default stone dust in packer/crafting table recipes. Important because small/tiny limestone dust cannot be obtained as a result.