### PR TITLE
Add circuit to tabular alumina recipe

### DIFF
--- a/groovy/postInit/materials/ceramics/Alumina.groovy
+++ b/groovy/postInit/materials/ceramics/Alumina.groovy
@@ -49,6 +49,7 @@ Sintering.RotaryKiln.fuels.each { fuel ->
     Sintering.RotaryKiln.comburents.each { comburent ->
         ROTARY_KILN.recipeBuilder()
                 .inputs(ore('dustAlumina'))
+                .circuitMeta(1)
                 .outputs(metaitem('dustTabularAlumina'))
                 .fluidInputs(fluid(fuel.name) * fuel.amountRequired)
                 .fluidInputs(fluid(comburent.name) * comburent.amountRequired)


### PR DESCRIPTION
## What
Hot CAC clinker was not craftable because the recipe conflicted with tabular alumina.

## Outcome
Circuit 1 added to tabular alumina recipe.

