### PR TITLE
change parmigano-reggiano solidifer cheese form to nc

### DIFF
--- a/groovy/postInit/mod/GregTechFoodOption.groovy
+++ b/groovy/postInit/mod/GregTechFoodOption.groovy
@@ -183,6 +183,17 @@ CENTRIFUGE.recipeBuilder()
     .EUt(VA[LV])
     .buildAndRegister()
 
+// Brined Parmigiano-Reggiano Roll * 1
+mods.gregtech.fluid_solidifier.removeByInput(16, [metaitem('gregtechfoodoption:component.cheese_form')], [fluid('gtfo_parmigiano_reggiano_starter') * 1000])
+
+SOLIDIFIER.recipeBuilder()
+    .fluidInputs(fluid('gtfo_parmigiano_reggiano_starter') * 1000)
+    .notConsumable(metaitem('gregtechfoodoption:component.cheese_form'))
+    .outputs(metaitem('gregtechfoodoption:component.brined_parmigiano_roll'))
+    .duration(150)
+    .EUt(16)
+    .buildAndRegister()
+
 FERMENTER.recipeBuilder()
     .inputs(metaitem('gregtechfoodoption:component.brined_parmigiano_roll') * 64)
     .fluidInputs(fluid('air') * 10000)


### PR DESCRIPTION
## What
  Cheese Form is consumed when making Brined Parmigiano-Reggiano Roll in the Fluid
  Solidifier when it shouldn't be, like other molds in the pack

  ## Implementation Details
  removes the recipe registered by GTFO and readds it with `.notConsumable()` on the Cheese form

  ## Outcome
  Fixes the cheese form being consumed in the Brined Parmigiano-Reggiano Roll Fluid Solidifier recipe

  ## Potential Compatibility Issues
  existing automation piping the Cheese Roll Form as a (if for whatever reason someone actually did that) consumable input will need to be adjusted