### PR TITLE
Update microblocks.cfg to add support for modded blocks

### DIFF
--- a/config/microblocks.cfg
+++ b/config/microblocks.cfg
@@ -577,6 +577,8 @@
 "susy:susy_stone_smooth":0-15
 "susy:susy_stone_cobble":0-15
 "susy:susy_stone_bricks":0-15
+"susy:bmrf_blocks":0-15
+"susy:s2bmrf_blocks":0-15
 
 "gregtech:warning_sign":0-15
 "gregtech:warning_sign_1":0-15
@@ -683,8 +685,6 @@
 "quark:sandstone_new":0-3
 "quark:red_sandstone_new":0-3
 
-"supercritical:plasma_fission_casing":0
-"supercritical:nuclear_casing":0
-"supercritical:radiation_shielding_casing":0
-"supercritical:dense_lead_block":0
-"supercritical:borated_concrete":0
+"supercritical:fission_casing":0-3
+"supercritical:nuclear_casing":0-1
+"supercritical:panelling":0-15

--- a/config/microblocks.cfg
+++ b/config/microblocks.cfg
@@ -3,3 +3,688 @@
 #<name> is the registry key of the block/item enclosed in quotes. NEI can help you find these
 #<meta> may be ommitted, in which case it defaults to 0, otherwise it can be a number, a comma separated list of numbers, or a dash separated range
 #Ex. "dirt" "minecraft:planks":3 "iron_ore":1,2,3,5 "ThermalFoundation:Storage":0-15
+
+# Embers Rekindeled
+"embers:block_copper"
+#"embers:block_lead" # Can't be cut by the saw
+#"embers:block_silver" # Can't be cut by the saw
+#"embers:block_dawnstone" # Can't be cut by the saw
+#"embers:ore_copper" # Can't be cut by the saw
+#"embers:ore_lead" # Can't be cut by the saw
+#"embers:ore_silver" # Can't be cut by the saw
+"embers:block_caminite_brick"
+"embers:ashen_stone"
+"embers:ashen_brick"
+"embers:ashen_tile"
+"embers:archaic_bricks"
+"embers:archaic_edge"
+"embers:archaic_tile"
+"embers:archaic_light"
+#"embers:ore_quartz" # Can't be cut by the saw
+"embers:sealed_planks"
+"embers:wrapped_sealed_planks"
+#"embers:block_aluminum" # Can't be cut by the saw
+#"embers:ore_aluminum" # Can't be cut by the saw
+#"embers:block_bronze" # Can't be cut by the saw
+#"embers:block_electrum" # Can't be cut by the saw
+#"embers:block_nickel" # Can't be cut by the saw
+#"embers:ore_nickel" # Can't be cut by the saw
+#"embers:block_tin" # Can't be cut by the saw
+#"embers:ore_tin" # Can't be cut by the saw
+
+# Chisel
+"chisel:blockaluminum":0-6
+"chisel:andesite":0-15
+"chisel:andesite1":0-15
+"chisel:andesite2":0
+"chisel:basalt":0-15
+"chisel:basalt1":0-9
+"chisel:basalt2":0-7
+"chisel:antiblock":0-15
+"chisel:bookshelf_oak":0-9
+"chisel:bookshelf_spruce":0-9
+"chisel:bookshelf_birch":0-9
+"chisel:bookshelf_jungle":0-9
+"chisel:bookshelf_acacia":0-9
+"chisel:bookshelf_darkoak":0-9
+"chisel:bricks":0-15
+"chisel:bricks1":0-9
+"chisel:bricks2":0-5
+"chisel:block_bronze":0-6
+"chisel:brownstone":0-9
+"chisel:certus":0-15
+"chisel:certus1":0-15
+"chisel:certus2":0-1
+"chisel:block_charcoal":0-15
+"chisel:block_charcoal1":0-15
+"chisel:block_charcoal2":0-1
+"chisel:cloud":0-4
+"chisel:blockcobalt":0-6
+"chisel:cobblestone":0-15
+"chisel:cobblestone1":0-9
+"chisel:cobblestone2":0-9
+"chisel:block_coal":0-15
+"chisel:block_coal1":0-15
+"chisel:block_coal2":0-1
+"chisel:block_coal_coke":0-15
+"chisel:block_coal_coke1":0-15
+"chisel:block_coal_coke2":0-1
+"chisel:cobblestonemossy":0-15
+"chisel:cobblestonemossy1":0-15
+"chisel:cobblestonemossy2":0
+"chisel:concrete_black":0-15
+"chisel:concrete_black1":0-15
+"chisel:concrete_black2":0
+"chisel:concrete_red":0-15
+"chisel:concrete_red1":0-15
+"chisel:concrete_red2":0
+"chisel:concrete_green":0-15
+"chisel:concrete_green1":0-15
+"chisel:concrete_green2":0
+"chisel:concrete_brown":0-15
+"chisel:concrete_brown1":0-15
+"chisel:concrete_brown2":0
+"chisel:concrete_blue":0-15
+"chisel:concrete_blue1":0-15
+"chisel:concrete_blue2":0
+"chisel:concrete_purple":0-15
+"chisel:concrete_purple1":0-15
+"chisel:concrete_purple2":0
+"chisel:concrete_cyan":0-15
+"chisel:concrete_cyan1":0-15
+"chisel:concrete_cyan2":0
+"chisel:concrete_lightgray":0-15
+"chisel:concrete_lightgray1":0-15
+"chisel:concrete_lightgray2":0
+"chisel:concrete_gray":0-15
+"chisel:concrete_gray1":0-15
+"chisel:concrete_gray2":0
+"chisel:concrete_pink":0-15
+"chisel:concrete_pink1":0-15
+"chisel:concrete_pink2":0
+"chisel:concrete_lime":0-15
+"chisel:concrete_lime1":0-15
+"chisel:concrete_lime2":0
+"chisel:concrete_yellow":0-15
+"chisel:concrete_yellow1":0-15
+"chisel:concrete_yellow2":0
+"chisel:concrete_lightblue":0-15
+"chisel:concrete_lightblue1":0-15
+"chisel:concrete_lightblue2":0
+"chisel:concrete_magenta":0-15
+"chisel:concrete_magenta1":0-15
+"chisel:concrete_magenta2":0
+"chisel:concrete_orange":0-15
+"chisel:concrete_orange1":0-15
+"chisel:concrete_orange2":0
+"chisel:concrete_white":0-15
+"chisel:concrete_white1":0-15
+"chisel:concrete_white2":0
+"chisel:blockcopper":0-6
+"chisel:diamond":0-11
+"chisel:diorite":0-15
+"chisel:diorite1":0-15
+"chisel:diorite2":0
+"chisel:dirt":0-15
+"chisel:blockelectrum":0-6
+"chisel:emerald":0-13
+"chisel:purpur":0-15
+"chisel:purpur1":0-9
+"chisel:purpur2":0-4
+"chisel:endstone":0-15
+"chisel:endstone1":0-9
+"chisel:endstone2":0-6
+"chisel:factory":0-15
+"chisel:factory1":0-4
+"chisel:futura":0-1
+#"chisel:futura":2-5 # No animated textures and some strange behaviour
+"chisel:glass":0-15
+"chisel:glass1":0-1
+"chisel:glassdyedblack":0-5
+"chisel:glassdyedred":0-5
+"chisel:glassdyedgreen":0-5
+"chisel:glassdyedbrown":0-5
+"chisel:glassdyedblue":0-5
+"chisel:glassdyedpurple":0-5
+"chisel:glassdyedcyan":0-5
+"chisel:glassdyedlightgray":0-5
+"chisel:glassdyedgray":0-5
+"chisel:glassdyedpink":0-5
+"chisel:glassdyedlime":0-5
+"chisel:glassdyedyellow":0-5
+"chisel:glassdyedlightblue":0-5
+"chisel:glassdyedmagenta":0-5
+"chisel:glassdyedorange":0-5
+"chisel:glassdyedwhite":0-5
+"chisel:glowstone":0-15
+"chisel:glowstone1":0-15
+"chisel:glowstone2":0
+"chisel:blockgold":0-6
+"chisel:gold":0-13
+"chisel:granite":0-15
+"chisel:granite1":0-15
+"chisel:granite2":0
+"chisel:hardenedclay":0-15
+"chisel:hardenedclay1":0-9
+"chisel:hardenedclay2":0-6
+"chisel:ice":0-15
+"chisel:ice1":0-15
+"chisel:ice2":0
+"chisel:icepillar":0-6
+"chisel:blockinvar":0-6
+"chisel:blockiron":0-6
+"chisel:iron":0-14
+"chisel:laboratory":0-15
+"chisel:lapis":0-8
+#"chisel:lavastone":0-15 # Will only show the lava texture
+#"chisel:lavastone1":0-15 # Will only show the lava texture
+#"chisel:lavastone2":0 # Will only show the lava texture
+"chisel:blocklead":0-6
+"chisel:limestone":0-15
+"chisel:limestone1":0-9
+"chisel:limestone2":0-7
+"chisel:marble":0-15
+"chisel:marble1":0-9
+"chisel:marble2":0-7
+"chisel:marblepillar":0-15
+"chisel:netherbrick":0-15
+"chisel:netherrack":0-13
+"chisel:blocknickel":0-6
+"chisel:obsidian":0-14
+"chisel:paper":0-8
+"chisel:planks-oak":0-14
+"chisel:planks-spruce":0-14
+"chisel:planks-birch":0-14
+"chisel:planks-jungle":0-14
+"chisel:planks-acacia":0-14
+"chisel:planks-dark-oak":0-14
+"chisel:blockplatinum":0-6
+"chisel:prismarine":0-15
+"chisel:prismarine1":0-9
+"chisel:prismarine2":0-5
+"chisel:quartz":0-15
+"chisel:quartz1":0-15
+"chisel:redstone":0-15
+"chisel:redstone1":0-11
+"chisel:sandstoneyellow":0-15
+"chisel:sandstoneyellow1":0-9
+"chisel:sandstoneyellow2":0-7
+"chisel:sandstonered":0-15
+"chisel:sandstonered1":0-9
+"chisel:sandstonered2":0-7
+"chisel:sandstone-scribbles":0-15
+"chisel:sandstonered-scribbles":0-15
+"chisel:blocksilver":0-6
+"chisel:blocksteel":0-6
+"chisel:stonebrick":0-15
+"chisel:stonebrick1":0-9
+"chisel:stonebrick2":0-9
+"chisel:technical":0-15
+"chisel:technical1":0-4
+"chisel:technicalnew":0-8
+#"chisel:temple":0-15 # Will only show the missing texture texture
+#"chisel:templemossy":0-15 # Will only show the missing texture texture
+"chisel:blocktin":0-6
+"chisel:tyrian":0-15
+"chisel:blockuranium":0-6
+"chisel:valentines":0-9
+"chisel:voidstone":0-7
+#"chisel:energizedvoidstone":0-7 # Will only show the non-animated part of the texture
+"chisel:voidstonerunic":0-14
+"chisel:voidstonerunic":0-14
+#"chisel:waterstone":0-15 # Will only show the water texture
+#"chisel:waterstone1":0-15 # Will only show the water texture
+#"chisel:waterstone2":0
+"chisel:wool_red":0-1
+"chisel:wool_green":0-1
+"chisel:wool_brown":0-1
+"chisel:wool_blue":0-1
+"chisel:wool_purple":0-1
+"chisel:wool_cyan":0-1
+"chisel:wool_lightgray":0-1
+"chisel:wool_gray":0-1
+"chisel:wool_pink":0-1
+"chisel:wool_lime":0-1
+"chisel:wool_yellow":0-1
+"chisel:wool_lightblue":0-1
+"chisel:wool_magenta":0-1
+"chisel:wool_orange":0-1
+"chisel:wool_white":0-1
+
+# Ender IO
+#"enderio:block_fused_glass":0-15 # Microblock gets black opaque instead of transparent
+#"enderio:block_fused_quartz":0-15 # Can't be cut by the saw
+#"enderio:block_enlightened_fused_quartz":0-15 # Can't be cut by the saw
+#"enderio:block_dark_fused_quartz":0-15 # Can't be cut by the saw
+"enderio:block_alloy":0-9
+
+# Thermal Foundation
+"thermalfoundation:storage":0-8
+#"thermalfoundation:storage_alloy":0-7 # Can't be cut by the saw
+"thermalfoundation:storage_resource":0-1
+"thermalfoundation:glass":0-8
+"thermalfoundation:glass_alloy":0-7
+"thermalfoundation:rockwool":0-15
+"thermalfoundation:ore":0-8
+"thermalfoundation:ore_fluid":0-5
+
+# Applied Energistics 2
+"appliedenergistics2:quartz_ore"
+#"appliedenergistics2:charged_quartz_ore" # Renders as vanilla stone
+"appliedenergistics2:quartz_block"
+"appliedenergistics2:quartz_pillar"
+"appliedenergistics2:chiseled_quartz_block"
+"appliedenergistics2:quartz_glass"
+"appliedenergistics2:quartz_vibrant_glass"
+"appliedenergistics2:fluix_block"
+#"appliedenergistics2:sky_stone_block" # Can't be cut by the saw
+"appliedenergistics2:smooth_sky_stone_block"
+"appliedenergistics2:sky_stone_brick"
+"appliedenergistics2:sky_stone_small_brick"
+
+# Coral Reef
+"coralreef:reef":0-1
+
+# Dark Utilities
+"darkutils:pearl_block":0-3
+"darkutils:wither_block":0-5
+
+# Rats
+"rats:block_of_cheese"
+"rats:marbled_cheese_raw"
+"rats:marbled_cheese"
+"rats:marbled_cheese_tile"
+"rats:marbled_cheese_chiseled"
+"rats:marbled_cheese_pillar"
+"rats:marbled_cheese_brick"
+"rats:marbled_cheese_brick_chiseled"
+"rats:marbled_cheese_brick_cracked"
+"rats:marbled_cheese_brick_mossy"
+#"rats:marbled_cheese_dirt" # Renders as vanilla dirt
+#"rats:marbled_cheese_grass" # Renders as vanilla grass (but green tinted)
+
+# Pam's Harvestcraft
+"harvestcraft:waxcomb"
+"harvestcraft:pressedwax"
+"harvestcraft:honeycomb"
+"harvestcraft:honey"
+"harvestcraft:pampaperbark"
+"harvestcraft:pamcinnamon"
+
+# Immersive Engineering
+"immersiveengineering:ore":0-1
+#"immersiveengineering:ore":2-5 # Can't be cut by the saw
+"immersiveengineering:storage":0-2
+#"immersiveengineering:storage":3-8 # Can't be cut by saw
+"immersiveengineering:stone_decoration":0-10
+"immersiveengineering:treated_wood":0-2
+"immersiveengineering:sheetmetal":0-10
+
+# Magneticraft
+"magneticraft:limestone":0-2
+"magneticraft:burnt_limestone":0-2
+"magneticraft:tile_limestone":0-1
+"magneticraft:ores":0-1
+"magneticraft:ores":2-3
+"magneticraft:ores":4
+"magneticraft:storage_blocks":0-4
+
+
+# Natura
+"natura:clouds":0-3
+"natura:colored_grass":0-2
+"natura:overworld_logs":0-3
+"natura:overworld_logs2":0-3
+#"natura:redwood_logs":0-2 # Can't cut with saw
+"natura:overworld_leaves":0-3
+"natura:overworld_leaves2":0-3
+"natura:redwood_leaves"
+"natura:overworld_planks":0-8
+"natura:nether_logs":0-2
+#"natura:nether_logs2":0,15 # Can't cut with saw
+"natura:nether_leaves":0-2
+"natura:nether_leaves2":0-2
+"natura:nether_planks":0-3
+"natura:nether_heat_sand"
+"natura:nether_tainted_soil":0-2
+"natura:nether_glass":0-1
+"natura:nether_green_large_glowshroom"
+"natura:nether_blue_large_glowshroom"
+"natura:nether_purple_large_glowshroom"
+
+# Tinkers' Construct
+"tconstruct:firewood":0-1
+"tconstruct:deco_ground"
+"tconstruct:clear_glass"
+"tconstruct:clear_stained_glass":0-15
+"tconstruct:metal":0,1,2,3,4,6
+"tconstruct:slime_leaves":0-2
+"tconstruct:seared":0-11
+"tconstruct:dried_clay":0-1
+"tconstruct:brownstone":0-11
+
+# Astral Sorcery
+"astralsorcery:blockmarble":0,1,3,4,5,6
+"astralsorcery:blockblackmarble":0,1,3,4,5,6
+"astralsorcery:blockinfusedwood":0,1,3,4,5,6
+
+# Ceramics
+"ceramics:clay_hard":0-7
+"ceramics:clay_soft"
+"ceramics:porcelain":0-15
+"ceramics:rainbow_clay":0-7
+
+# ChineseWorkshop
+"chineseworkshop:black_brick_wall"
+"chineseworkshop:black_clay_block"
+"chineseworkshop:andesite_pavement"
+"chineseworkshop:white_gray_wall"
+"chineseworkshop:rammed_earth"
+#"chineseworkshop:rouge_brick" # Makes the block look wrong even when uncut
+"chineseworkshop:red_stained_wooden_planks"
+
+# Extended crafting
+#"extendedcrafting:storage":0-7 # Shimmer effects lost so no real point
+
+# Integrated Dynamics
+"integrateddynamics:menril_log"
+"integrateddynamics:menril_log_filled"
+"integrateddynamics:menril_leaves"
+"integrateddynamics:menril_planks"
+"integrateddynamics:crystalized_menril_block"
+"integrateddynamics:crystalized_menril_brick"
+"integrateddynamics:crystalized_chorus_block"
+"integrateddynamics:crystalized_chorus_brick"
+
+# Integrated Terminals
+"integratedterminals:menril_glass"
+"integratedterminals:chorus_glass"
+
+# MatterOverdrive: Legacy Edition
+"matteroverdrive:tritanium_block"
+"matteroverdrive:decorative.stripes"
+"matteroverdrive:decorative.coils"
+"matteroverdrive:decorative.clean"
+"matteroverdrive:decorative.vent.dark"
+"matteroverdrive:decorative.vent.bright"
+"matteroverdrive:decorative.holo_matrix"
+"matteroverdrive:decorative.tritanium_plate"
+"matteroverdrive:decorative.tritanium_plate_stripe"
+"matteroverdrive:decorative.carbon_fiber_plate"
+"matteroverdrive:decorative.matter_tube"
+"matteroverdrive:decorative.beams"
+"matteroverdrive:decorative.floor_tiles"
+"matteroverdrive:decorative.floor_tile_white"
+"matteroverdrive:decorative.floor_tiles_green"
+"matteroverdrive:decorative.floor_noise"
+"matteroverdrive:decorative.white_plate"
+"matteroverdrive:decorative.separator"
+"matteroverdrive:decorative.tritanium_plate_colored"
+"matteroverdrive:decorative.engine_exhaust_plasma"
+"matteroverdrive:industrial_glass"
+
+# Mekanism
+"mekanism:plasticblock":0-15
+"mekanism:slickplasticblock":0-15
+"mekanism:glowplasticblock":0-15
+"mekanism:reinforcedplasticblock":0-15
+"mekanism:roadplasticblock":0-15
+"mekanism:saltblock"
+"mekanism:basicblock":0,2,3,4
+
+# Mystical Agradditions
+"mysticalagradditions:storage":0-3
+
+# Mystical Agriculture
+"mysticalagriculture:storage":0-5
+"mysticalagriculture:ingot_storage":0-6
+"mysticalagriculture:coal_block":0-4
+"mysticalagriculture:soulstone":0-6
+"mysticalagriculture:soul_glass"
+
+# NuclearCraft
+"nuclearcraft:ingot_block":3-11
+
+# Pickle Tweaks
+"pickletweaks:colored_cobblestone":0-15
+"pickletweaks:dark_glass"
+
+# Rustic
+"rustic:stone_pillar"
+"rustic:andesite_pillar"
+"rustic:diorite_pillar"
+"rustic:granite_pillar"
+"rustic:slate_pillar"
+"rustic:slate"
+"rustic:slate_roof"
+"rustic:slate_tile"
+"rustic:slate_brick"
+"rustic:slate_chiseled"
+"rustic:painted_wood_white"
+"rustic:painted_wood_orange"
+"rustic:painted_wood_magenta"
+"rustic:painted_wood_light_blue"
+"rustic:painted_wood_yellow"
+"rustic:painted_wood_lime"
+"rustic:painted_wood_pink"
+"rustic:painted_wood_gray"
+"rustic:painted_wood_silver"
+"rustic:painted_wood_cyan"
+"rustic:painted_wood_purple"
+"rustic:painted_wood_blue"
+"rustic:painted_wood_brown"
+"rustic:painted_wood_green"
+"rustic:painted_wood_red"
+"rustic:painted_wood_black"
+"rustic:planks":0-1
+"rustic:log":0-1
+"rustic:leaves":0-1
+"rustic:leaves_apple"
+
+# The Twilight Forest
+"twilightforest:twilight_log":0-3
+"twilightforest:root":0-1
+"twilightforest:twilight_leaves":0-3
+"twilightforest:maze_stone":0-7
+"twilightforest:hedge"
+"twilightforest:naga_stone":0-1
+"twilightforest:magic_log":0-3
+"twilightforest:magic_leaves":0-3
+"twilightforest:tower_wood":0-4
+"twilightforest:underbrick":0-2
+"twilightforest:twilight_leaves_3":0-1
+"twilightforest:deadrock":0-2
+"twilightforest:dark_leaves"
+"twilightforest:aurora_pillar"
+"twilightforest:knightmetal_block"
+"twilightforest:castle_brick":0-5
+"twilightforest:castle_pillar":0-3
+#"twilightforest:castle_rune_brick":0-3 # Texture break when cut
+#"twilightforest:block_storage":0-4 # Textures break when cut
+"twilightforest:etched_nagastone"
+"twilightforest:nagastone_pillar"
+"twilightforest:nagastone_pillar_mossy"
+"twilightforest:etched_nagastone_weathered"
+"twilightforest:nagastone_pillar_weathered"
+"twilightforest:aruoralized_glass"
+
+# Sky Orchards
+"sky_orchards:amber_cottonwood"
+"sky_orchards:amber_dirt"
+"sky_orchards:amber_petrified"
+"sky_orchards:amber_clay"
+"sky_orchards:amber_sand"
+"sky_orchards:amber_gravel"
+"sky_orchards:amber_coal"
+"sky_orchards:amber_iron"
+"sky_orchards:amber_gold"
+"sky_orchards:amber_lapis"
+"sky_orchards:amber_redstone"
+"sky_orchards:amber_diamond"
+"sky_orchards:amber_bone"
+"sky_orchards:amber_cookie"
+"sky_orchards:amber_bacon"
+"sky_orchards:amber_donut"
+"sky_orchards:amber_copper"
+"sky_orchards:amber_lead"
+"sky_orchards:amber_tin"
+"sky_orchards:amber_silver"
+"sky_orchards:amber_nickel"
+"sky_orchards:amber_emerald"
+"sky_orchards:amber_quartz"
+"sky_orchards:amber_netherrack"
+"sky_orchards:amber_glowstone"
+"sky_orchards:amber_cobalt"
+"sky_orchards:amber_ardite"
+"sky_orchards:amber_osmium"
+"sky_orchards:amber_prosperity"
+
+"xtones:agon":0-15
+"xtones:azur":0-15
+"xtones:bitt":0-15
+"xtones:cray":0-15
+"xtones:fort":0-15
+"xtones:glaxx":0-15
+"xtones:iszm":0-15
+"xtones:jelt":0-15
+"xtones:korp":0-15
+"xtones:kryp":0-15
+"xtones:lair":0-15
+"xtones:lave":0-15
+"xtones:mint":0-15
+"xtones:myst":0-15
+"xtones:reds":0-15
+"xtones:reed":0-15
+"xtones:roen":0-15
+"xtones:sols":0-15
+"xtones:sync":0-15
+"xtones:tank":0-15
+"xtones:vect":0-15
+"xtones:vena":0-15
+"xtones:zane":0-15
+"xtones:zech":0-15
+"xtones:zest":0-15
+"xtones:zeta":0-15
+"xtones:zion":0-15
+"xtones:zkul":0-15
+"xtones:zoea":0-15
+"xtones:zome":0-15
+"xtones:zone":0-15
+"xtones:zorg":0-15
+"xtones:ztyl":0-15
+"xtones:zyth":0-15
+
+"susy:susy_stone_smooth":0-15
+"susy:susy_stone_cobble":0-15
+"susy:susy_stone_bricks":0-15
+
+"gregtech:warning_sign":0-15
+"gregtech:warning_sign_1":0-15
+"gregtech:metal_sheet":0-15
+"gregtech:studs":0-15
+"gregtech:borderless_white_lamp":0-15
+"gregtech:borderless_orange_lamp":0-15
+"gregtech:borderless_magenta_lamp":0-15
+"gregtech:borderless_light_blue_lamp":0-15
+"gregtech:borderless_yellow_lamp":0-15
+"gregtech:borderless_lime_lamp":0-15
+"gregtech:borderless_pink_lamp":0-15
+"gregtech:borderless_gray_lamp":0-15
+"gregtech:borderless_silver_lamp":0-15
+"gregtech:borderless_cyan_lamp":0-15
+"gregtech:borderless_purple_lamp":0-15
+"gregtech:borderless_blue_lamp":0-15
+"gregtech:borderless_brown_lamp":0-15
+"gregtech:borderless_green_lamp":0-15
+"gregtech:borderless_red_lamp":0-15
+"gregtech:borderless_black_lamp":0-15
+"gregtech:asphalt":0-15
+"gregtech:stone_smooth":0-15
+"gregtech:stone_cobble":0-15
+"gregtech:stone_cobble_mossy":0-15
+"gregtech:stone_bricks":0-15
+"gregtech:stone_bricks_mossy":0-15
+"gregtech:stone_tiled":0-15
+"gregtech:stone_bricks_small":0-15
+"gregtech:stone_windmill_b":0-15
+"gregtech:stone_bricks_square":0-15
+"gregtech:planks":0-15
+
+"biomesoplenty:dirt":0-5
+"biomesoplenty:dried_sand":0
+"biomesoplenty:hard_ice":0
+"biomesoplenty:mud":0
+"biomesoplenty:flesh":0
+"biomesoplenty:ash_block":0
+"biomesoplenty:hive":0-3
+"biomesoplenty:crystal":0
+"biomesoplenty:gem_block":0-7
+"biomesoplenty:white_sand":0
+"biomesoplenty:white_sandstone":0-2
+"biomesoplenty:planks_0":0-15
+"biomesoplenty:log_0":0-15
+"biomesoplenty:log_1":0-15
+"biomesoplenty:log_2":0-15
+"biomesoplenty:log_3":0-15
+"biomesoplenty:cherry_stairs":0-7
+"biomesoplenty:ebony_stairs":0-7
+"biomesoplenty:ethereal_stairs":0-7
+"biomesoplenty:eucalyptus_stairs":0-7
+"biomesoplenty:fir_stairs":0-7
+"biomesoplenty:hellbark_stairs":0-7
+"biomesoplenty:jacaranda_stairs":0-7
+"biomesoplenty:magic_stairs":0-7
+"biomesoplenty:mahogany_stairs":0-7
+"biomesoplenty:mangrove_stairs":0-7
+"biomesoplenty:palm_stairs":0-7
+"biomesoplenty:pine_stairs":0-7
+"biomesoplenty:redwood_stairs":0-7
+"biomesoplenty:sacred_oak_stairs":0-7
+"biomesoplenty:umbran_stairs":0-7
+"biomesoplenty:willow_stairs":0-7
+
+"engineersdecor:clinker_brick_block":0
+"engineersdecor:clinker_brick_stained_block":0
+"engineersdecor:clinker_brick_slipped_block":0
+"engineersdecor:slag_brick_block":0
+"engineersdecor:rebar_concrete_block":0
+"engineersdecor:rebar_concrete_tile":0
+"engineersdecor:gas_concrete_block":0
+"engineersdecor:thick_concrete_wall":0
+"engineersdecor:panzerglass_block":0
+
+# --- Woods & Planks ---
+"quark:vertical_planks":0-5
+"quark:stained_planks":0-15
+# --- Bricks, Pavements & Shingles ---
+"quark:charred_nether_bricks":0
+"quark:magma_bricks":0
+"quark:snow_bricks":0
+"quark:iron_plate":0
+"quark:rusty_iron_plate":0
+"quark:midori_block":0
+"quark:shingles":0-15
+# --- World Stones & Variations ---
+"quark:marble":0-3
+"quark:limestone":0-3
+"quark:jasper":0-3
+"quark:slate":0-3
+"quark:biotite_block":0-2
+"quark:elder_prismarine":0-2
+"quark:duskbound_block":0
+"quark:soul_sandstone":0-2
+# --- Polished & Architectural Blocks ---
+"quark:polished_netherrack":0
+"quark:carved_wood":0-5
+"quark:hardened_clay_tiles":0-15
+"quark:stained_clay_tiles":0-15
+"quark:reed_block":0
+"quark:thatch":0
+"quark:sandstone_new":0-3
+"quark:red_sandstone_new":0-3
+
+"supercritical:plasma_fission_casing":0
+"supercritical:nuclear_casing":0
+"supercritical:radiation_shielding_casing":0
+"supercritical:dense_lead_block":0
+"supercritical:borated_concrete":0


### PR DESCRIPTION
## What
Make microblocks' saw actually useful. Part of config was taken long ago from somewhere on the internet.

## Potential Compatibility Issues
Only potential *visual* texture issues on some blocks. Here is relevant part of config describing existing issues (they're, of course, commented out):
```cfg
#"chisel:futura":2-5 # No animated textures and some strange behaviour
#"chisel:temple":0-15 # Will only show the missing texture texture
#"chisel:templemossy":0-15 # Will only show the missing texture texture
#"chisel:energizedvoidstone":0-7 # Will only show the non-animated part of the texture
#"chisel:waterstone":0-15 # Will only show the water texture
#"chisel:waterstone1":0-15 # Will only show the water texture
```
