### PR TITLE
Fix NeodymiumChain hydroclorirc dupe

### DIFF
--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/lanthanides/separations/BastnasiteProcessing.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/lanthanides/separations/BastnasiteProcessing.groovy
@@ -189,7 +189,7 @@ MIXER_SETTLER.recipeBuilder()
 
     BR.recipeBuilder()
         .inputs(ore('dustBastOxPrNdConcentrate'))
-        .fluidInputs(fluid('hydrochloric_acid') * 324)
+        .fluidInputs(fluid('hydrochloric_acid') * 648)
         .chancedOutput(metaitem('dustPraseodymiumIvOxide'), 1200, 0)
         .fluidOutputs(fluid('neodymium_chloride_solution') * 648)
         .duration(2000)

--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/lanthanides/separations/MonaziteProcessing.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/lanthanides/separations/MonaziteProcessing.groovy
@@ -182,7 +182,7 @@ MIXER_SETTLER.recipeBuilder()
 
     BR.recipeBuilder()
         .inputs(ore('dustMonaOxPrNdConcentrate'))
-        .fluidInputs(fluid('hydrochloric_acid') * 459)
+        .fluidInputs(fluid('hydrochloric_acid') * 918)
         .chancedOutput(metaitem('dustPraseodymiumIvOxide') * 3, 410, 0)
         .fluidOutputs(fluid('neodymium_chloride_solution') * 918)
         .duration(2000)

--- a/groovy/prePostInit/ModifyRecipeMaps.groovy
+++ b/groovy/prePostInit/ModifyRecipeMaps.groovy
@@ -385,6 +385,12 @@ mods.gregtech.bender.removeByInput(24, [metaitem('ingotPolyphenyleneSulfide'), m
 // Ethenone * 100
 mods.gregtech.fluid_heater.removeByInput(30, [metaitem('circuit.integrated').withNbt(['Configuration': 1])], [fluid('acetone') * 100])
 
+//Remove SuperCon Centrifuge
+mods.gregtech.centrifuge.removeByInput(30, [metaitem('dustSamariumIronArsenicOxide')*4],null)
+mods.gregtech.centrifuge.removeByInput(30, [metaitem('dustUraniumTriplatinum')*4],null)
+mods.gregtech.centrifuge.removeByInput(30, [metaitem('dustUraniumRhodiumDinaquadide')*4],null)
+mods.gregtech.centrifuge.removeByInput(30, [metaitem('dustEnrichedNaquadahTriniumEuropiumDuranide')*10],null)
+
 RecipeMaps.SIFTER_RECIPES
     .modifyMaxFluidInputs(1)
     .modifyMaxFluidOutputs(1)


### PR DESCRIPTION
By producing half the amount the dupe doesnt ocurr.

## What
Neodyium chloride used hydrocluric acid to be created, it uses half the amount of neodiym chloride produce. For 3000ml of neodiyum you produce 6000ml of diluted hydrocluric which is 3000ml of hydrocluric. As you need half the amount to produce that amount of neodiym hydrolucric you are producing doublee diluted. This PR fixes the dupe.

## Implementation Details
Changed the amount of fluid produce to 3000ml instead of 6000 for neodyim chloride fixing both bastanite and monzaite lines.

## Outcome
No more dupes
