### PR TITLE
Fixed hydrogen balance in all the UO2 reaction furnace recipes

### DIFF
--- a/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/actinides/UraniumChain.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/elements/f_block/actinides/UraniumChain.groovy
@@ -182,7 +182,7 @@ LCR.recipeBuilder()
 
 REACTION_FURNACE.recipeBuilder()
     .inputs(ore('dustAmmoniumDiuranate') * 19)
-    .fluidInputs(fluid('hydrogen') * 2000)
+    .fluidInputs(fluid('hydrogen') * 4000)
     .outputs(metaitem('dustUraniumDioxide') * 6)
     .fluidOutputs(fluid('ammonia') * 2000)
     .fluidOutputs(fluid('dense_steam') * 3000)

--- a/groovy/postInit/chemistry/inorganic_chemistry/isotopes/UraniumEnrichment.groovy
+++ b/groovy/postInit/chemistry/inorganic_chemistry/isotopes/UraniumEnrichment.groovy
@@ -89,7 +89,7 @@ for (grade in uranium_grades) {
 
     REACTION_FURNACE.recipeBuilder()
         .inputs(ore('dust' + grade_adu + 'AmmoniumDiuranate') * 19)
-        .fluidInputs(fluid('hydrogen') * 2000)
+        .fluidInputs(fluid('hydrogen') * 4000)
         .outputs(metaitem('dust' + grade_uo2 + 'Dioxide') * 6)
         .fluidOutputs(fluid('ammonia') * 2000)
         .fluidOutputs(fluid('dense_steam') * 3000)


### PR DESCRIPTION
## What
All the Reaction Furnace recipes for UO2 variants had 10 H on the left and 12 H on the right.

## Outcome
Increased H input from 2kL to 4kL to balance it out.
