### PR TITLE
Gas Atomizer quest pre-reqs

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/5/336324327.json
+++ b/config/betterquesting/DefaultQuests/Quests/5/336324327.json
@@ -1,9 +1,11 @@
 {
   "preRequisiteTypes:7": [
+    1,
     1
   ],
   "preRequisites:11": [
-    757
+    757,
+    90454916
   ],
   "properties:10": {
     "betterquesting:10": {


### PR DESCRIPTION
## What
Now locked behind Hot Isostatic Press quest (needed for boron nitride nozzle).
